### PR TITLE
Fix/no negatives and no duplicate questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "deploy": "gh-pages -d build",
     "e2e": "cypress open"
   },
- "browserslist": [
+  "browserslist": [
     ">0.2%",
     "not dead",
     "not ie <= 11",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   semi: false,
   singleQuote: true,
-  tabWidth: 2
+  tabWidth: 2,
+  printWidth: 80
 }

--- a/src/App.js
+++ b/src/App.js
@@ -36,15 +36,16 @@ function App() {
 
   const handleSubmit = useCallback(() => {
     dispatch({ type: types.CHECK_ANSWER })
+    if (submitInputRef.current) submitInputRef.current.focus()
   }, [dispatch])
 
   const activeTheme = themes[mode]
 
-  // Equivalent of componentDidMount and componentDidUpdate when numOfEnemies changes
+  // Equivalent of componentDidMount
   useEffect(() => {
     dispatch({ type: types.NEW_PROBLEM })
     if (submitInputRef.current) submitInputRef.current.focus()
-  }, [numOfEnemies])
+  }, [])
 
   return (
     <View

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,5 @@
-
 import React, { useReducer, useCallback, useEffect, useRef } from 'react'
-import {
-  StyleSheet,
-  Text,
-  View,
-  TextInput,
-  Button,
-  Picker
-} from 'react-native'
+import { StyleSheet, Text, View, TextInput, Button, Picker } from 'react-native'
 import { reducer, initialState, types } from './AppReducer'
 
 import './App.css'
@@ -20,7 +12,7 @@ function App() {
 
   let submitInputRef = useRef()
 
-  // useCallback helps prevent rerendering via memoization
+  // useCallback helps prevent re-rendering via memoization
   const handleAnswerChange = useCallback(
     value => {
       dispatch({ type: types.SET_ANSWER, payload: value })
@@ -64,7 +56,7 @@ function App() {
         style={styles.picker}
         onValueChange={handleModePicker}
       >
-        <Picker.Item label="Additon(+)" value="addition" />
+        <Picker.Item label="Addition(+)" value="addition" />
         <Picker.Item label="Subtraction(-)" value="subtraction" />
         <Picker.Item label="Multiplication(*)" value="multiplication" />
         <Picker.Item label="Division(/)" value="division" />

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -13,20 +13,22 @@ export const types = {
 
 export function reducer(state, action) {
   switch (action.type) {
-    case types.RESTART:
+    case types.RESTART: {
       const restartState = { ...initialState }
       restartState.mode = state.mode
       restartState.operator = state.operator
 
       return reducer(restartState, { type: types.NEW_PROBLEM })
+    }
 
-    case types.SET_ANSWER:
+    case types.SET_ANSWER: {
       return {
         ...state,
         answer: action.payload
       }
+    }
 
-    case types.ADD_ENEMY:
+    case types.ADD_ENEMY: {
       if (state.numOfEnemies < 6) {
         return {
           ...state,
@@ -34,8 +36,9 @@ export function reducer(state, action) {
         }
       }
       break
+    }
 
-    case types.REMOVE_ENEMY:
+    case types.REMOVE_ENEMY: {
       const newState = { ...state }
       newState.numOfEnemies--
 
@@ -44,8 +47,9 @@ export function reducer(state, action) {
       }
 
       return newState
+    }
 
-    case types.CHECK_ANSWER:
+    case types.CHECK_ANSWER: {
       let answer = parseInt(state.answer, 10)
       // example: eval('2 + 4'); Note: eval is safe here because we control the input
       // eslint-disable-next-line no-eval
@@ -59,30 +63,39 @@ export function reducer(state, action) {
 
       // Update problem
       return reducer(stateWithEnemies, { type: types.NEW_PROBLEM })
+    }
 
-    case types.NEW_PROBLEM:
-      if (state.mode === 'division') {
-        let x = randomNumberGenerator(1, 9)
-        let y = randomNumberGenerator(1, 9)
-        let z = x * y
-        if (z > 9) {
-          return reducer(state, { type: types.NEW_PROBLEM })
-        }
-        return {
-          ...state,
-          val1: z,
-          val2: y,
-          answer: ''
-        }
+    case types.NEW_PROBLEM: {
+      let x
+      let y
+
+      switch (state.mode) {
+        case 'division':
+          x = randomNumberGenerator(1, 9)
+          y = randomNumberGenerator(1, Math.floor(9 / x)) // keeps x *= y below 10
+          x *= y // divide by `y` to get back `x`
+          break
+        default:
+          x = randomNumberGenerator(1, 9)
+          y = randomNumberGenerator(1, 9)
       }
-      return {
+
+      const newState = {
         ...state,
-        val1: randomNumberGenerator(1, 9),
-        val2: randomNumberGenerator(1, 9),
+        val1: x,
+        val2: y,
         answer: ''
       }
 
-    case types.SET_MODE:
+      // if problem is the same, retry
+      if (newState.val1 === state.val1 || newState.val2 === state.val2) {
+        return reducer(state, { type: types.NEW_PROBLEM })
+      }
+
+      return newState
+    }
+
+    case types.SET_MODE: {
       const mode = action.payload
       return reducer(
         {
@@ -92,6 +105,7 @@ export function reducer(state, action) {
         },
         { type: types.NEW_PROBLEM }
       )
+    }
 
     default:
       throw new Error(`Invalid action ${action.type}`)

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -50,10 +50,10 @@ export function reducer(state, action) {
     }
 
     case types.CHECK_ANSWER: {
-      let answer = parseInt(state.answer, 10)
+      const answer = parseInt(state.answer, 10)
       // example: eval('2 + 4'); Note: eval is safe here because we control the input
       // eslint-disable-next-line no-eval
-      let expected = eval(`${state.val1} ${state.operator} ${state.val2}`)
+      const expected = eval(`${state.val1} ${state.operator} ${state.val2}`)
 
       // Update enemies & won
       const stateWithEnemies =

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -70,11 +70,19 @@ export function reducer(state, action) {
       let y
 
       switch (state.mode) {
-        case 'division':
+        case 'division': {
           x = randomNumberGenerator(1, 9)
           y = randomNumberGenerator(1, Math.floor(9 / x)) // keeps x *= y below 10
           x *= y // divide by `y` to get back `x`
           break
+        }
+
+        case 'subtraction': {
+          x = randomNumberGenerator(1, 9)
+          y = randomNumberGenerator(1, x)
+          break
+        }
+
         default:
           x = randomNumberGenerator(1, 9)
           y = randomNumberGenerator(1, 9)

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -88,19 +88,17 @@ export function reducer(state, action) {
           y = randomNumberGenerator(1, 9)
       }
 
-      const newState = {
+      // if problem is the same, retry
+      if (x === state.val1 || y === state.val2) {
+        return reducer(state, { type: types.NEW_PROBLEM })
+      }
+
+      return {
         ...state,
         val1: x,
         val2: y,
         answer: ''
       }
-
-      // if problem is the same, retry
-      if (newState.val1 === state.val1 || newState.val2 === state.val2) {
-        return reducer(state, { type: types.NEW_PROBLEM })
-      }
-
-      return newState
     }
 
     case types.SET_MODE: {

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -89,7 +89,7 @@ export function reducer(state, action) {
       }
 
       // if problem is the same, retry
-      if (x === state.val1 || y === state.val2) {
+      if (x === state.val1 && y === state.val2) {
         return reducer(state, { type: types.NEW_PROBLEM })
       }
 


### PR DESCRIPTION
This PR refactors the `case type.CHECK_ANSWER:` to handle subtraction (disallows negatives) and prevents duplicate questions. It also changes the way division is handled (no recursion).

Fixes #15 and #9 

# Changes

* Wrapped each case-statement in curly braces (creating their own scope) to prevent variable declarations from clashing.
* Division problem generation changed: the upper bound for the random number generator is `Math.floor(MAX_NUMBER / x)` (where `MAX_NUMBER` is hardcoded as 9 for now).
* Subtraction problem generation: generate `x`, then set the upper bound for the random number generator to `x` so that `x` will always be `>= y`
* Fixed a bug introduced by #12 It was causing a new problem to be created every time `numOfEnemies` changed after a new problem had already been created. This also caused duplicate problems to be created no matter what solution was used.
To keep the autofocus from this PR I copied the line to `handleSubmit`
* Fixed typo in `App.js`
* Added `printWidth` to the prettier config

## Notes

It would probably be wise to introduce a settings object of some sort to avoid hardcoding any more difficulty based number generating mechanisms for future difficulty based features.