### PR TITLE
Used "createRoot" instead of "ReactDOM.render"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
Fixes Issue #70 

Used **createRoot** function from _react-dom/client_, instead of **ReactDOM.render**
This fixes a Warning generated by react 18.