### PR TITLE
feat: add negative numbers mode and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ The game will consists of difficulties ranging from easy to hard
 | Medium | Contains digits ranging from 10-99 |
 | Hard | Contains digits ranging from 100-999 |
 
-The standard gameplay will consists of an answer of a whole number. However, if the children wanted to add more complicated calculations, they can choose to change the mode a "Decimal", which is rounded to two decimal places.
+The standard gameplay will consist of whole number answers. Players can also select a **Mode Type** to change the structure of the questions:
+
+| Mode Type | Description |
+| --- | --- |
+| Whole Number | Standard integers (default) |
+| Decimals | Numbers with up to two decimal places |
+| Negatives | Introduces negative numbers into problems |
+
+These mode types combine with the difficulty and operator settings, giving children a wide range of practice scenarios.
 
 ### Built With
 
@@ -46,8 +54,10 @@ npm run build
 
 ### Roadmap
 
-- [x] Simple UI with Additions, Substract, Multiplication, Divide questions.
-- [x] Background music
+- [x] Simple UI with Addition, Subtraction, Multiplication, Division questions
+- [x] Background music and sound effects
 - [x] Deploy to github pages
+- [x] Character art for hero and enemies
+- [x] Difficulty selection (Easy, Medium, Hard)
+- [x] Mode types (Whole Number, Decimals, Negatives)
 - [ ] Point System
-- [x] Character Arts enemies

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
   // useCallback helps prevent re-rendering via memoization
   const handleAnswerChange = useCallback(
     (value: string) => {
-      if (/^\d+|[.]$/.test(value.toString()) || value === '') {
+      if (/^-?\d*\.?\d*$/.test(value.toString()) || value === '') {
         dispatch({ type: TYPES.SET_ANSWER, payload: value });
       }
     },
@@ -227,6 +227,7 @@ function App() {
           >
             <Picker.Item label="Whole Number" value="wholeNumber" />
             <Picker.Item label="Decimals" value="decimal" />
+            <Picker.Item label="Negatives" value="negative" />
           </Picker>
         </View>
 
@@ -268,7 +269,7 @@ function App() {
                 nativeID="val1"
                 style={[styles.mathText, { color: activeTheme.textColor }]}
               >
-                {val1}
+                {val1 < 0 ? `(${val1})` : val1}
               </Text>
               <Text
                 nativeID="operator"
@@ -280,7 +281,7 @@ function App() {
                 nativeID="val2"
                 style={[styles.mathText, { color: activeTheme.textColor }]}
               >
-                {val2}
+                {val2 < 0 ? `(${val2})` : val2}
               </Text>
               <Text style={[styles.mathText, { color: activeTheme.textColor }]}>
                 =

--- a/src/AppReducer.test.ts
+++ b/src/AppReducer.test.ts
@@ -210,6 +210,38 @@ describe('reducer', () => {
       expect(Number.isInteger(result.val1)).toBe(true);
       expect(Number.isInteger(result.val2)).toBe(true);
     });
+
+    it('changes mode type to negative', () => {
+      const state = makeState({ modeType: 'wholeNumber' });
+      const result = reducer(state, {
+        type: TYPES.SET_MODE_TYPES,
+        payload: 'negative',
+      });
+
+      expect(result.modeType).toBe('negative');
+    });
+
+    it('generates at least one negative value in negative mode', () => {
+      let sawNegative = false;
+      for (let i = 0; i < 50; i++) {
+        const state = makeState({ modeType: 'negative' });
+        const result = reducer(state, { type: TYPES.NEW_PROBLEM });
+        if (result.val1 < 0 || result.val2 < 0) {
+          sawNegative = true;
+          break;
+        }
+      }
+      expect(sawNegative).toBe(true);
+    });
+
+    it('negative mode produces integers (not decimals)', () => {
+      for (let i = 0; i < 20; i++) {
+        const state = makeState({ modeType: 'negative' });
+        const result = reducer(state, { type: TYPES.NEW_PROBLEM });
+        expect(Number.isInteger(result.val1)).toBe(true);
+        expect(Number.isInteger(result.val2)).toBe(true);
+      }
+    });
   });
 
   describe('ADD_ENEMY', () => {


### PR DESCRIPTION
## Summary
- Add **Negatives** as a new mode type in the mode selector, letting children practice math with negative numbers
- Update input validation to accept negative answers (minus sign) and wrap negative operands in parentheses for clarity
- Add unit tests for the negative mode (mode type switching, negative value generation, integer validation)
- Update README with current mode types table and roadmap

## Test plan
- [x] All 45 existing tests pass
- [x] New tests verify negative mode type switching, negative value generation, and integer output
- [x] Prettier formatting verified clean
- [ ] Manual testing: select "Negatives" mode and verify negative numbers appear in problems

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)