### PR TITLE
feat: add timer-based scoring system

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ yarn start
 npm run build
 ```
 
+### Scoring System
+
+Each question starts a 30-second countdown timer. Faster correct answers earn more points:
+
+| Speed | Points |
+| --- | --- |
+| Under 5 seconds | 10 |
+| Under 10 seconds | 8 |
+| Under 15 seconds | 6 |
+| Under 20 seconds | 4 |
+| Under 25 seconds | 2 |
+| 25 seconds or more | 1 |
+
+Wrong answers earn 0 points. Your total score accumulates across all questions, and your best score for the session is tracked. The timer changes color as time runs low (green to yellow to red) to keep things exciting!
+
 ### Roadmap
 
 - [x] Simple UI with Addition, Subtraction, Multiplication, Division questions
@@ -60,4 +75,4 @@ npm run build
 - [x] Character art for hero and enemies
 - [x] Difficulty selection (Easy, Medium, Hard)
 - [x] Mode types (Whole Number, Decimals, Negatives)
-- [ ] Point System
+- [x] Point System

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,10 @@
-import React, { useReducer, useCallback, useEffect, useRef } from 'react';
+import React, {
+  useReducer,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   StyleSheet,
   Text,
@@ -34,9 +40,17 @@ function App() {
       isStoredState,
       soundEnabled,
       highContrast,
+      score,
+      questionStartTime,
+      bestScore,
+      lastPointsEarned,
     },
     dispatch,
   ] = useReducer(reducer, initialState);
+
+  const [timeLeft, setTimeLeft] = useState(30);
+  const [showPoints, setShowPoints] = useState(false);
+  const pointsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   let submitInputRef = useRef<TextInput>(null);
 
@@ -205,6 +219,31 @@ function App() {
     submitInputRef.current && submitInputRef.current.focus();
   }, [val1, val2]);
 
+  // Start timer when a new problem appears
+  useEffect(() => {
+    if (won) return;
+    dispatch({ type: TYPES.START_TIMER });
+    setTimeLeft(30);
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [val1, val2, won]);
+
+  // Show points earned animation
+  useEffect(() => {
+    if (lastPointsEarned === null) return;
+    setShowPoints(true);
+    if (pointsTimeoutRef.current) clearTimeout(pointsTimeoutRef.current);
+    pointsTimeoutRef.current = setTimeout(() => setShowPoints(false), 1500);
+    return () => {
+      if (pointsTimeoutRef.current) clearTimeout(pointsTimeoutRef.current);
+    };
+  }, [lastPointsEarned, val1, val2]);
+
+  const timerColor =
+    timeLeft > 15 ? '#4caf50' : timeLeft > 5 ? '#ff9800' : '#f44336';
+
   return (
     <View
       style={[styles.root, { backgroundColor: activeTheme.backgroundColor }]}
@@ -259,6 +298,39 @@ function App() {
           </Picker>
         </View>
 
+        <View style={styles.scoreTimerRow} accessibilityLiveRegion="polite">
+          <Text
+            style={[styles.timerText, { color: timerColor }]}
+            testID="timer"
+          >
+            {`\u23F1 ${timeLeft}s`}
+          </Text>
+          <Text
+            style={[styles.scoreText, { color: activeTheme.textColor }]}
+            testID="score"
+          >
+            {`Score: ${score}`}
+          </Text>
+          <Text
+            style={[styles.bestScoreText, { color: activeTheme.textColor }]}
+            testID="best-score"
+          >
+            {`Best: ${bestScore}`}
+          </Text>
+          {showPoints && lastPointsEarned !== null && (
+            <Text
+              style={[
+                styles.pointsEarned,
+                {
+                  color: lastPointsEarned > 0 ? '#4caf50' : '#f44336',
+                },
+              ]}
+              testID="points-earned"
+            >
+              {`+${lastPointsEarned}`}
+            </Text>
+          )}
+        </View>
         <View
           style={styles.enemyCount}
           accessibilityLiveRegion="polite"
@@ -293,12 +365,23 @@ function App() {
           </View>
         </View>
         {won ? (
-          <View>
+          <View style={{ alignItems: 'center' }}>
             <Text
               style={{ color: activeTheme.textColor, fontSize: 32 }}
               accessibilityRole="text"
             >
               Victory!
+            </Text>
+            <Text
+              style={{
+                color: activeTheme.textColor,
+                fontSize: 24,
+                fontFamily: '"Comic Sans MS", cursive, sans-serif',
+                paddingVertical: 8,
+              }}
+              accessibilityRole="text"
+            >
+              {`Final Score: ${score}`}
             </Text>
             <Button
               onPress={handleRestart}
@@ -525,6 +608,33 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 4,
     borderRadius: 6,
+  },
+  scoreTimerRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+    paddingVertical: 4,
+  },
+  timerText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+  },
+  scoreText: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+  },
+  bestScoreText: {
+    fontSize: 16,
+    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+    opacity: 0.8,
+  },
+  pointsEarned: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    fontFamily: '"Comic Sans MS", cursive, sans-serif',
   },
   enemyCount: {
     paddingVertical: 4,

--- a/src/AppReducer.test.ts
+++ b/src/AppReducer.test.ts
@@ -3,6 +3,7 @@ import {
   initialState,
   TYPES,
   randomNumberGenerator,
+  calculatePoints,
   AppState,
   ActionType,
 } from './AppReducer';
@@ -468,6 +469,135 @@ describe('reducer', () => {
     });
   });
 
+  describe('START_TIMER', () => {
+    it('sets questionStartTime to current time', () => {
+      const now = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const state = makeState({ questionStartTime: 0 });
+      const result = reducer(state, { type: TYPES.START_TIMER });
+      expect(result.questionStartTime).toBe(now);
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('CHECK_ANSWER with scoring', () => {
+    it('awards 10 points for a correct answer under 5 seconds', () => {
+      const startTime = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(startTime + 3000);
+      const state = makeState({
+        val1: 2,
+        val2: 3,
+        operator: '+',
+        mode: 'addition',
+        answer: '5',
+        numOfEnemies: 3,
+        modeType: 'wholeNumber',
+        questionStartTime: startTime,
+        score: 0,
+        bestScore: 0,
+      });
+      const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+      expect(result.score).toBe(10);
+      expect(result.lastPointsEarned).toBe(10);
+      jest.restoreAllMocks();
+    });
+
+    it('awards 8 points for a correct answer under 10 seconds', () => {
+      const startTime = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(startTime + 7000);
+      const state = makeState({
+        val1: 2,
+        val2: 3,
+        operator: '+',
+        mode: 'addition',
+        answer: '5',
+        numOfEnemies: 3,
+        modeType: 'wholeNumber',
+        questionStartTime: startTime,
+        score: 0,
+        bestScore: 0,
+      });
+      const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+      expect(result.score).toBe(8);
+      jest.restoreAllMocks();
+    });
+
+    it('awards 0 points for a wrong answer', () => {
+      const startTime = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(startTime + 2000);
+      const state = makeState({
+        val1: 2,
+        val2: 3,
+        operator: '+',
+        mode: 'addition',
+        answer: '999',
+        numOfEnemies: 3,
+        modeType: 'wholeNumber',
+        questionStartTime: startTime,
+        score: 5,
+        bestScore: 5,
+      });
+      const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+      expect(result.score).toBe(5);
+      expect(result.lastPointsEarned).toBe(0);
+      jest.restoreAllMocks();
+    });
+
+    it('accumulates score across multiple correct answers', () => {
+      const startTime = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(startTime + 3000);
+      const state = makeState({
+        val1: 2,
+        val2: 3,
+        operator: '+',
+        mode: 'addition',
+        answer: '5',
+        numOfEnemies: 3,
+        modeType: 'wholeNumber',
+        questionStartTime: startTime,
+        score: 20,
+        bestScore: 20,
+      });
+      const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+      expect(result.score).toBe(30);
+      jest.restoreAllMocks();
+    });
+
+    it('updates bestScore when score exceeds it', () => {
+      const startTime = 1700000000000;
+      jest.spyOn(Date, 'now').mockReturnValue(startTime + 3000);
+      const state = makeState({
+        val1: 2,
+        val2: 3,
+        operator: '+',
+        mode: 'addition',
+        answer: '5',
+        numOfEnemies: 3,
+        modeType: 'wholeNumber',
+        questionStartTime: startTime,
+        score: 50,
+        bestScore: 55,
+      });
+      const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+      expect(result.score).toBe(60);
+      expect(result.bestScore).toBe(60);
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('RESTART with scoring', () => {
+    it('resets score to 0 but preserves bestScore', () => {
+      const state = makeState({
+        score: 42,
+        bestScore: 58,
+        won: true,
+      });
+      const result = reducer(state, { type: TYPES.RESTART });
+      expect(result.score).toBe(0);
+      expect(result.bestScore).toBe(58);
+    });
+  });
+
   describe('invalid action', () => {
     it('throws an error for unknown action types', () => {
       const state = makeState();
@@ -475,5 +605,39 @@ describe('reducer', () => {
         reducer(state, { type: 999 as any });
       }).toThrow('Invalid action 999');
     });
+  });
+});
+
+describe('calculatePoints', () => {
+  it('returns 10 for under 5 seconds', () => {
+    expect(calculatePoints(0)).toBe(10);
+    expect(calculatePoints(2000)).toBe(10);
+    expect(calculatePoints(4999)).toBe(10);
+  });
+
+  it('returns 8 for under 10 seconds', () => {
+    expect(calculatePoints(5000)).toBe(8);
+    expect(calculatePoints(9999)).toBe(8);
+  });
+
+  it('returns 6 for under 15 seconds', () => {
+    expect(calculatePoints(10000)).toBe(6);
+    expect(calculatePoints(14999)).toBe(6);
+  });
+
+  it('returns 4 for under 20 seconds', () => {
+    expect(calculatePoints(15000)).toBe(4);
+    expect(calculatePoints(19999)).toBe(4);
+  });
+
+  it('returns 2 for under 25 seconds', () => {
+    expect(calculatePoints(20000)).toBe(2);
+    expect(calculatePoints(24999)).toBe(2);
+  });
+
+  it('returns 1 for 25 seconds or more', () => {
+    expect(calculatePoints(25000)).toBe(1);
+    expect(calculatePoints(30000)).toBe(1);
+    expect(calculatePoints(100000)).toBe(1);
   });
 });

--- a/src/AppReducer.ts
+++ b/src/AppReducer.ts
@@ -23,6 +23,7 @@ export const TYPES = {
   RESTORE_STATE: 9,
   SET_SOUND_ENABLED: 10,
   SET_HIGH_CONTRAST: 11,
+  START_TIMER: 12,
 } as const;
 
 const OPERATORS = {
@@ -63,6 +64,10 @@ export type AppState = {
   isStoredState: boolean;
   soundEnabled: boolean;
   highContrast: boolean;
+  score: number;
+  questionStartTime: number;
+  bestScore: number;
+  lastPointsEarned: number | null;
 };
 
 export const initialState: AppState = {
@@ -79,7 +84,25 @@ export const initialState: AppState = {
   isStoredState: true,
   soundEnabled: true,
   highContrast: false,
+  score: 0,
+  questionStartTime: 0,
+  bestScore: 0,
+  lastPointsEarned: null,
 };
+
+/**
+ * Calculate points earned based on how quickly the answer was given.
+ * Faster answers earn more points.
+ */
+export function calculatePoints(elapsedMs: number): number {
+  const seconds = elapsedMs / 1000;
+  if (seconds < 5) return 10;
+  if (seconds < 10) return 8;
+  if (seconds < 15) return 6;
+  if (seconds < 20) return 4;
+  if (seconds < 25) return 2;
+  return 1;
+}
 
 export const reducer: Reducer<AppState, ActionType> = (state, action) => {
   const randomNumber = (
@@ -167,6 +190,8 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         val1: val[0],
         val2: val[1],
         operator: state.operator,
+        bestScore: state.bestScore,
+        questionStartTime: Date.now(),
       };
     }
 
@@ -217,14 +242,31 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
 
       console.log(expected);
 
+      const isCorrect = answer === expected;
+
+      // Calculate points based on elapsed time
+      const elapsed = Date.now() - state.questionStartTime;
+      const pointsEarned = isCorrect ? calculatePoints(elapsed) : 0;
+      const newScore = state.score + pointsEarned;
+      const newBestScore = Math.max(state.bestScore, newScore);
+
       // Update enemies & won
-      const stateWithEnemies =
-        answer === expected
-          ? reducer(state, { type: TYPES.REMOVE_ENEMY })
-          : reducer(state, { type: TYPES.ADD_ENEMY });
+      const stateWithEnemies = isCorrect
+        ? reducer(state, { type: TYPES.REMOVE_ENEMY })
+        : reducer(state, { type: TYPES.ADD_ENEMY });
 
       // Update problem
-      return reducer(stateWithEnemies, { type: TYPES.NEW_PROBLEM });
+      const stateWithProblem = reducer(stateWithEnemies, {
+        type: TYPES.NEW_PROBLEM,
+      });
+
+      return {
+        ...stateWithProblem,
+        score: newScore,
+        bestScore: newBestScore,
+        lastPointsEarned: pointsEarned,
+        questionStartTime: Date.now(),
+      };
     }
 
     case TYPES.NEW_PROBLEM: {
@@ -240,6 +282,7 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         val1: val[0],
         val2: val[1],
         answer: '',
+        questionStartTime: state.questionStartTime || Date.now(),
       };
     }
 
@@ -296,6 +339,13 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
     case TYPES.RESTORE_STATE: {
       const storedState = action.payload as AppState;
       return { ...storedState, isStoredState: true };
+    }
+
+    case TYPES.START_TIMER: {
+      return {
+        ...state,
+        questionStartTime: Date.now(),
+      };
     }
 
     default:


### PR DESCRIPTION
## Summary
- Added a 30-second countdown timer that starts with each new math problem, with color changes (green/yellow/red) as time runs low
- Implemented point-based scoring: faster correct answers earn more points (10 for <5s, 8 for <10s, down to 1 for 25s+), wrong answers earn 0
- Score accumulates across questions with best score tracking per session, plus a brief points-earned animation (+10, +0, etc.)
- Added `calculatePoints` helper, `START_TIMER` action, and extended state with `score`, `bestScore`, `questionStartTime`, `lastPointsEarned`

Closes #100

## Test plan
- [x] All 58 existing + new unit tests pass
- [x] `calculatePoints` tested for all 6 time tiers
- [x] `CHECK_ANSWER` tested with mocked `Date.now()` for score calculation
- [x] `RESTART` verified to reset score but preserve bestScore
- [x] `START_TIMER` verified to set questionStartTime
- [ ] Manual: verify timer counts down and resets on new problem
- [ ] Manual: verify points animation appears and fades after 1.5s
- [ ] Manual: verify final score shown on victory screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)