### PR TITLE
feat: replace Comic Sans with Google Fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,9 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Battle Math</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Poppins:wght@400;600;700&family=Quicksand:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -367,7 +367,11 @@ function App() {
         {won ? (
           <View style={{ alignItems: 'center' }}>
             <Text
-              style={{ color: activeTheme.textColor, fontSize: 32 }}
+              style={{
+                color: activeTheme.textColor,
+                fontSize: 32,
+                fontFamily: '"Fredoka One", "Quicksand", sans-serif',
+              }}
               accessibilityRole="text"
             >
               Victory!
@@ -376,7 +380,7 @@ function App() {
               style={{
                 color: activeTheme.textColor,
                 fontSize: 24,
-                fontFamily: '"Comic Sans MS", cursive, sans-serif',
+                fontFamily: '"Poppins", sans-serif',
                 paddingVertical: 8,
               }}
               accessibilityRole="text"
@@ -511,7 +515,7 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 32,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Fredoka One", "Quicksand", sans-serif',
   },
   pickerContainer: {
     flexDirection: 'row',
@@ -520,7 +524,7 @@ const styles = StyleSheet.create({
     height: 40,
     width: 150,
     borderRadius: 8,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Quicksand", sans-serif',
     textAlign: 'center',
     marginLeft: 10,
   },
@@ -556,7 +560,8 @@ const styles = StyleSheet.create({
   },
   mathText: {
     fontSize: 40,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Poppins", sans-serif',
+    fontWeight: '700',
   },
   input: {
     height: 60,
@@ -567,7 +572,7 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 40,
     borderRadius: 8,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Poppins", sans-serif',
   },
   button: {
     height: 60,
@@ -580,19 +585,23 @@ const styles = StyleSheet.create({
   buttonText: {
     color: '#fff',
     fontSize: 40,
+    fontFamily: '"Quicksand", sans-serif',
+    fontWeight: '700',
   },
   msgTextError: {
     color: 'red',
     fontSize: 25,
+    fontFamily: '"Quicksand", sans-serif',
   },
   msgTextSuccess: {
     color: 'green',
     fontSize: 25,
+    fontFamily: '"Quicksand", sans-serif',
   },
   submitMsgWrapper: {
     paddingBottom: 15,
     fontSize: 40,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Quicksand", sans-serif',
   },
   soundControls: {
     flexDirection: 'row',
@@ -603,7 +612,7 @@ const styles = StyleSheet.create({
   soundToggleText: {
     color: '#fff',
     fontSize: 16,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Quicksand", sans-serif',
     backgroundColor: 'rgba(0,0,0,0.4)',
     paddingHorizontal: 10,
     paddingVertical: 4,
@@ -619,40 +628,42 @@ const styles = StyleSheet.create({
   timerText: {
     fontSize: 24,
     fontWeight: 'bold',
-    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+    fontFamily: '"Poppins", sans-serif',
   },
   scoreText: {
     fontSize: 22,
     fontWeight: 'bold',
-    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+    fontFamily: '"Poppins", sans-serif',
   },
   bestScoreText: {
     fontSize: 16,
-    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+    fontFamily: '"Poppins", sans-serif',
     opacity: 0.8,
   },
   pointsEarned: {
     fontSize: 22,
     fontWeight: 'bold',
-    fontFamily: '"Comic Sans MS", cursive, sans-serif',
+    fontFamily: '"Poppins", sans-serif',
   },
   enemyCount: {
     paddingVertical: 4,
   },
   enemyCountText: {
     fontSize: 20,
-    fontFamily: `"Comic Sans MS", cursive, sans-serif`,
+    fontFamily: '"Quicksand", sans-serif',
     fontWeight: 'bold',
   },
   msgTextErrorHC: {
     color: '#ff6b6b',
     fontSize: 25,
     fontWeight: 'bold',
+    fontFamily: '"Quicksand", sans-serif',
   },
   msgTextSuccessHC: {
     color: '#69ff69',
     fontSize: 25,
     fontWeight: 'bold',
+    fontFamily: '"Quicksand", sans-serif',
   },
 });
 


### PR DESCRIPTION
## Summary
- Replaced all Comic Sans MS font references with child-friendly Google Fonts
- **Fredoka One** for titles (Battle Math heading, Victory text)
- **Quicksand** for body text/labels (buttons, pickers, messages, enemy count, settings)
- **Poppins** for numbers (math equations, score, timer, points earned, input)
- Added Google Fonts preconnect and stylesheet links to `index.html`

Closes #126

## Test plan
- [ ] Verify fonts load correctly in browser (check Network tab for Google Fonts CSS)
- [ ] Confirm title uses Fredoka One (rounded, playful display font)
- [ ] Confirm math equation numbers use Poppins (clean, legible numerals)
- [ ] Confirm buttons and labels use Quicksand (friendly, rounded body font)
- [ ] Check high contrast mode still renders correctly
- [ ] Verify all text remains at minimum 16px
- [ ] Test on slow connection (fonts should swap in via `display=swap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)