### PR TITLE
feat: celebration animations for correct answers and victories

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/react-native": "^0.70.4",
+    "canvas-confetti": "^1.9.4",
     "gh-pages": "^4.0.0",
     "react": "^18.2.0",
     "react-art": "^18.2.0",
@@ -42,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "@types/canvas-confetti": "^1.9.0",
     "cypress": "^10.8.0",
     "eslint-plugin-cypress": "^2.2.1",
     "husky": "^9.1.7",

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,33 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Battle Math</title>
+    <style>
+      @keyframes floatUp {
+        0% { opacity: 1; transform: translateY(0) scale(1); }
+        100% { opacity: 0; transform: translateY(-60px) scale(1.3); }
+      }
+      @keyframes shake {
+        10%, 90% { transform: translateX(-2px); }
+        20%, 80% { transform: translateX(4px); }
+        30%, 50%, 70% { transform: translateX(-6px); }
+        40%, 60% { transform: translateX(6px); }
+      }
+      @keyframes enemyDefeat {
+        0% { opacity: 1; transform: scale(1) rotate(0deg); }
+        50% { opacity: 0.5; transform: scale(0.5) rotate(20deg); }
+        100% { opacity: 0; transform: scale(0) rotate(40deg); }
+      }
+      @keyframes victoryBounce {
+        0% { transform: scale(0); opacity: 0; }
+        50% { transform: scale(1.2); opacity: 1; }
+        70% { transform: scale(0.9); }
+        100% { transform: scale(1); opacity: 1; }
+      }
+      @keyframes pulse {
+        0%, 100% { transform: scale(1); }
+        50% { transform: scale(1.06); }
+      }
+    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Poppins:wght@400;600;700&family=Quicksand:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
   TouchableOpacity,
   Image,
 } from 'react-native';
+import confetti from 'canvas-confetti';
 import { reducer, initialState, TYPES } from './AppReducer';
 import { useMsgAfterSubmit } from './hooks';
 import HeroSvg from './components/HeroSvg';
@@ -114,12 +115,16 @@ function App() {
       questionStartTime,
       bestScore,
       lastPointsEarned,
+      hintLevel,
     },
     dispatch,
   ] = useReducer(reducer, initialState);
   const [timeLeft, setTimeLeft] = useState(30);
   const [showPoints, setShowPoints] = useState(false);
   const pointsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [shaking, setShaking] = useState(false);
+  const [defeatingEnemy, setDefeatingEnemy] = useState(false);
+  const prevHintLevelRef = useRef(0);
   let submitInputRef = useRef<TextInput>(null);
   const variablesToLookFor: [number, number] = [
     previousNumOfEnemies,
@@ -133,10 +138,43 @@ function App() {
     if (isStoredState) return;
     if (numOfEnemies < previousNumOfEnemies) {
       if (soundEnabled) playCorrectSound();
+      // Correct answer confetti
+      setDefeatingEnemy(true);
+      confetti({
+        particleCount: 80,
+        spread: 70,
+        origin: { y: 0.6 },
+      });
+      setTimeout(() => setDefeatingEnemy(false), 500);
     } else if (numOfEnemies > previousNumOfEnemies) {
       if (soundEnabled) playIncorrectSound();
     }
   }, [numOfEnemies, previousNumOfEnemies, isStoredState, soundEnabled]);
+
+  // Wrong answer shake
+  useEffect(() => {
+    if (hintLevel > 0 && hintLevel > prevHintLevelRef.current) {
+      setShaking(true);
+      const timer = setTimeout(() => setShaking(false), 500);
+      return () => clearTimeout(timer);
+    }
+    prevHintLevelRef.current = hintLevel;
+  }, [hintLevel]);
+
+  // Victory celebration confetti
+  useEffect(() => {
+    if (!won) return;
+    const end = Date.now() + 3000;
+    const interval = setInterval(() => {
+      confetti({
+        particleCount: 50,
+        spread: 80,
+        origin: { x: Math.random(), y: Math.random() * 0.5 },
+      });
+      if (Date.now() > end) clearInterval(interval);
+    }, 250);
+    return () => clearInterval(interval);
+  }, [won]);
   const handleSoundToggle = useCallback(() => {
     dispatch({ type: TYPES.SET_SOUND_ENABLED, payload: !soundEnabled });
   }, [dispatch, soundEnabled]);
@@ -329,7 +367,12 @@ function App() {
                 <Text
                   style={[
                     styles.pointsEarned,
-                    { color: lastPointsEarned > 0 ? '#4caf50' : '#f44336' },
+                    {
+                      color: lastPointsEarned > 0 ? '#4caf50' : '#f44336',
+                      animationName: 'floatUp',
+                      animationDuration: '1.5s',
+                      animationFillMode: 'forwards',
+                    } as any,
                   ]}
                   testID="points-earned"
                 >{`+${lastPointsEarned}`}</Text>
@@ -398,7 +441,19 @@ function App() {
             </View>
             <View style={styles.enemiesContainer}>
               {[...Array(numOfEnemies)].map((_, i) => (
-                <View testID="enemies" key={i}>
+                <View
+                  testID="enemies"
+                  key={i}
+                  style={
+                    defeatingEnemy && i === numOfEnemies - 1
+                      ? ({
+                          animationName: 'enemyDefeat',
+                          animationDuration: '0.5s',
+                          animationFillMode: 'forwards',
+                        } as any)
+                      : undefined
+                  }
+                >
                   <Image
                     source={require('./assets/images/orc.png')}
                     style={styles.characterImage}
@@ -410,27 +465,57 @@ function App() {
           </View>
           {won ? (
             <View style={[styles.cardPanel, styles.victoryPanel]}>
-              <Text style={styles.victoryText} accessibilityRole="text">
+              <Text
+                style={[
+                  styles.victoryText,
+                  {
+                    animationName: 'victoryBounce',
+                    animationDuration: '0.8s',
+                    animationFillMode: 'forwards',
+                  } as any,
+                ]}
+                accessibilityRole="text"
+              >
                 Victory!
               </Text>
               <Text
                 style={styles.victoryScore}
                 accessibilityRole="text"
               >{`Final Score: ${score}`}</Text>
+              <Text
+                style={styles.victoryBest}
+                accessibilityRole="text"
+              >{`Best Score: ${bestScore}`}</Text>
               <TouchableOpacity
                 onPress={handleRestart}
                 style={[
                   styles.restartButton,
-                  { backgroundColor: activeTheme.buttonColor },
+                  {
+                    backgroundColor: activeTheme.buttonColor,
+                    animationName: 'pulse',
+                    animationDuration: '1.5s',
+                    animationIterationCount: 'infinite',
+                  } as any,
                 ]}
                 accessibilityLabel="Play again"
                 accessibilityRole="button"
               >
-                <Text style={styles.restartButtonText}>Restart</Text>
+                <Text style={styles.restartButtonText}>Play Again</Text>
               </TouchableOpacity>
             </View>
           ) : (
-            <View style={[styles.mathContainer, styles.cardPanel]}>
+            <View
+              style={[
+                styles.mathContainer,
+                styles.cardPanel,
+                shaking
+                  ? ({
+                      animationName: 'shake',
+                      animationDuration: '0.5s',
+                    } as any)
+                  : undefined,
+              ]}
+            >
               {submitMessageBlock}
               <View style={styles.mathRow}>
                 <Text
@@ -636,6 +721,12 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontFamily: '"Poppins", sans-serif',
     paddingVertical: 8,
+  },
+  victoryBest: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 18,
+    fontFamily: '"Poppins", sans-serif',
+    paddingBottom: 8,
   },
   restartButton: {
     width: '100%',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,6 +1678,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/canvas-confetti@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz#d1077752e046413c9881fbb2ba34a70ebe3c1773"
+  integrity sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -2763,6 +2768,11 @@ caniuse-api@^3.0.0:
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001407:
   version "1.0.30001418"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz#5f459215192a024c99e3e3a53aac310fc7cf24e6"
+
+canvas-confetti@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/canvas-confetti/-/canvas-confetti-1.9.4.tgz#4412a5daa96afd0b4d70ecd66b65ce8db3022b2b"
+  integrity sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## Summary
- Confetti burst fires on every correct answer using canvas-confetti
- Floating "+N" points text animates upward and fades out when points are earned
- Enemy defeat animation (shrink + rotate + fade) plays on the last enemy when one is eliminated
- Math card panel shakes briefly on wrong answers
- Victory screen features bounce-in "Victory!" text, final/best score display, pulsing "Play Again" button, and 3 seconds of multi-burst confetti fireworks

## Test plan
- [x] All 92 existing tests pass with no changes needed
- [x] Verified correct answer triggers confetti and enemy defeat animation
- [x] Verified wrong answer triggers shake on the math panel
- [x] Verified victory screen shows animated text, scores, pulsing button, and celebration confetti
- [ ] Manual cross-browser check (Chrome, Firefox, Safari)

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)