### PR TITLE
feat: add hero and enemy character animations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,36 @@
         0%, 100% { transform: scale(1); }
         50% { transform: scale(1.06); }
       }
+      @keyframes heroIdle {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-6px); }
+      }
+      @keyframes heroAttack {
+        0% { transform: translateX(0); }
+        30% { transform: translateX(30px); }
+        100% { transform: translateX(0); }
+      }
+      @keyframes heroHurt {
+        10%, 90% { transform: translateX(-3px); }
+        20%, 80% { transform: translateX(3px); }
+        30%, 50%, 70% { transform: translateX(-5px); }
+        40%, 60% { transform: translateX(5px); }
+      }
+      @keyframes enemySway {
+        0%, 100% { transform: translateX(0); }
+        50% { transform: translateX(4px); }
+      }
+      @keyframes enemyEntrance {
+        0% { transform: scale(0) translateY(-30px); opacity: 0; }
+        60% { transform: scale(1.1) translateY(5px); opacity: 1; }
+        100% { transform: scale(1) translateY(0); opacity: 1; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+        }
+      }
     </style>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,8 @@ function App() {
   const pointsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [shaking, setShaking] = useState(false);
   const [defeatingEnemy, setDefeatingEnemy] = useState(false);
+  const [heroAnim, setHeroAnim] = useState<'idle' | 'attack' | 'hurt'>('idle');
+  const [newEnemyIndex, setNewEnemyIndex] = useState<number | null>(null);
   const prevHintLevelRef = useRef(0);
   let submitInputRef = useRef<TextInput>(null);
   const variablesToLookFor: [number, number] = [
@@ -140,14 +142,18 @@ function App() {
       if (soundEnabled) playCorrectSound();
       // Correct answer confetti
       setDefeatingEnemy(true);
+      setHeroAnim('attack');
       confetti({
         particleCount: 80,
         spread: 70,
         origin: { y: 0.6 },
       });
       setTimeout(() => setDefeatingEnemy(false), 500);
+      setTimeout(() => setHeroAnim('idle'), 400);
     } else if (numOfEnemies > previousNumOfEnemies) {
       if (soundEnabled) playIncorrectSound();
+      setNewEnemyIndex(numOfEnemies - 1);
+      setTimeout(() => setNewEnemyIndex(null), 500);
     }
   }, [numOfEnemies, previousNumOfEnemies, isStoredState, soundEnabled]);
 
@@ -155,7 +161,11 @@ function App() {
   useEffect(() => {
     if (hintLevel > 0 && hintLevel > prevHintLevelRef.current) {
       setShaking(true);
-      const timer = setTimeout(() => setShaking(false), 500);
+      setHeroAnim('hurt');
+      const timer = setTimeout(() => {
+        setShaking(false);
+        setHeroAnim('idle');
+      }, 400);
       return () => clearTimeout(timer);
     }
     prevHintLevelRef.current = hintLevel;
@@ -304,6 +314,25 @@ function App() {
       if (pointsTimeoutRef.current) clearTimeout(pointsTimeoutRef.current);
     };
   }, [lastPointsEarned, val1, val2]);
+  const heroAnimStyle: Record<string, React.CSSProperties> = {
+    idle: {
+      animationName: 'heroIdle',
+      animationDuration: '2s',
+      animationIterationCount: 'infinite',
+      animationTimingFunction: 'ease-in-out',
+    },
+    attack: {
+      animationName: 'heroAttack',
+      animationDuration: '0.4s',
+      animationIterationCount: 1 as any,
+      animationTimingFunction: 'ease-out',
+    },
+    hurt: {
+      animationName: 'heroHurt',
+      animationDuration: '0.4s',
+      animationIterationCount: 1 as any,
+    },
+  };
   const timerColor =
     timeLeft > 15 ? '#4caf50' : timeLeft > 5 ? '#ff9800' : '#f44336';
 
@@ -434,7 +463,10 @@ function App() {
               <View nativeID="hero" accessibilityLabel="Your hero character">
                 <Image
                   source={require('./assets/images/hero.png')}
-                  style={styles.characterImage}
+                  style={[
+                    styles.characterImage,
+                    heroAnimStyle[heroAnim] as any,
+                  ]}
                   accessibilityLabel="Hero"
                 />
               </View>
@@ -456,7 +488,24 @@ function App() {
                 >
                   <Image
                     source={require('./assets/images/orc.png')}
-                    style={styles.characterImage}
+                    style={[
+                      styles.characterImage,
+                      defeatingEnemy && i === numOfEnemies - 1
+                        ? undefined
+                        : newEnemyIndex === i
+                          ? ({
+                              animationName: 'enemyEntrance',
+                              animationDuration: '0.5s',
+                              animationFillMode: 'forwards',
+                            } as any)
+                          : ({
+                              animationName: 'enemySway',
+                              animationDuration: '1.5s',
+                              animationIterationCount: 'infinite',
+                              animationTimingFunction: 'ease-in-out',
+                              animationDelay: `${i * 0.3}s`,
+                            } as any),
+                    ]}
                     accessibilityLabel={`Enemy ${i + 1}`}
                   />
                 </View>


### PR DESCRIPTION
## Summary
- Hero character now bobs gently when idle, lunges forward on correct answer (attack), and shakes on wrong answer (hurt)
- Enemy characters sway continuously with staggered timing per enemy index, and new enemies bounce in with an entrance animation on spawn
- Added `prefers-reduced-motion` media query to respect user accessibility preferences

Closes #132

## Test plan
- [ ] Verify hero idle bobbing animation plays continuously
- [ ] Submit a correct answer and confirm hero lunges forward briefly
- [ ] Submit a wrong answer and confirm hero shakes briefly
- [ ] Confirm enemies sway with offset delays (each enemy starts slightly later)
- [ ] Submit enough wrong answers to spawn a new enemy and verify bounce entrance
- [ ] Enable "prefers-reduced-motion" in OS/browser settings and verify animations are suppressed
- [ ] All 92 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)