### PR TITLE
feat: add visual attempt indicator with hearts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -78,6 +78,11 @@
         60% { transform: scale(1.3); opacity: 1; }
         100% { transform: scale(1); opacity: 1; }
       }
+      @keyframes heartBreak {
+        0% { transform: scale(1); opacity: 1; }
+        50% { transform: scale(1.3); opacity: 0.5; }
+        100% { transform: scale(0.8); opacity: 0.4; }
+      }
       @keyframes enemyEntrance {
         0% { transform: scale(0) translateY(-30px); opacity: 0; }
         60% { transform: scale(1.1) translateY(5px); opacity: 1; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,6 +152,7 @@ function App() {
       bestScore,
       lastPointsEarned,
       hintLevel,
+      attempts,
       streak,
       maxStreak,
       streakBonus,
@@ -664,6 +665,31 @@ function App() {
               ))}
             </View>
           </View>
+          {/* === ATTEMPT HEARTS === */}
+          {!won && (
+            <View style={styles.heartsContainer} testID="hearts-container">
+              {[0, 1, 2].map((i) => (
+                <Text
+                  key={i}
+                  style={[
+                    styles.heart,
+                    i < 3 - attempts ? styles.heartFull : styles.heartEmpty,
+                    i === 3 - attempts && attempts > 0 && hintLevel > 0
+                      ? ({
+                          animationName: 'heartBreak',
+                          animationDuration: '0.5s',
+                        } as any)
+                      : undefined,
+                  ]}
+                  accessibilityLabel={
+                    i < 3 - attempts ? 'Heart full' : 'Heart empty'
+                  }
+                >
+                  {i < 3 - attempts ? '\u2764\uFE0F' : '\uD83D\uDDA4'}
+                </Text>
+              ))}
+            </View>
+          )}
           {won ? (
             <View style={[styles.cardPanel, styles.victoryPanel]}>
               <Text
@@ -940,6 +966,21 @@ const styles = StyleSheet.create({
     justifyContent: 'space-evenly',
   },
   characterImage: { width: 120, height: 120, resizeMode: 'contain' as any },
+  heartsContainer: {
+    flexDirection: 'row' as const,
+    justifyContent: 'center' as const,
+    gap: 8,
+    paddingVertical: 4,
+  },
+  heart: {
+    fontSize: 28,
+  },
+  heartFull: {
+    opacity: 1,
+  },
+  heartEmpty: {
+    opacity: 0.4,
+  },
   mathContainer: { paddingVertical: 16, alignItems: 'center' },
   mathRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Display 3 hearts above the math equation that deplete on wrong attempts, showing remaining tries at a glance
- Empty hearts render at reduced opacity with a black heart emoji; full hearts show red
- Added a `heartBreak` CSS animation that plays when a heart is lost

Closes #157

## Test plan
- [x] All 110 existing tests pass
- [ ] Verify 3 full hearts appear on a new problem
- [ ] Submit a wrong answer and confirm one heart depletes with animation
- [ ] Submit 3 wrong answers and confirm all hearts are empty before moving to next problem
- [ ] Confirm hearts reset to full on a new problem
- [ ] Hearts are hidden on the victory screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)