### PR TITLE
feat: add number pad for mobile input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { reducer, initialState, TYPES, getStreakMilestone } from './AppReducer';
 import { useMsgAfterSubmit } from './hooks';
 import HeroSvg from './components/HeroSvg';
 import Tutorial from './components/Tutorial';
+import NumberPad from './components/NumberPad';
 import bgSound from './assets/music/background-music.mp3';
 import BackgroundSound from './components/BackgroundSound';
 import {
@@ -174,6 +175,7 @@ function App() {
   const [defeatingEnemy, setDefeatingEnemy] = useState(false);
   const [heroAnim, setHeroAnim] = useState<'idle' | 'attack' | 'hurt'>('idle');
   const [newEnemyIndex, setNewEnemyIndex] = useState<number | null>(null);
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 600);
   const prevHintLevelRef = useRef(0);
   let submitInputRef = useRef<TextInput>(null);
   const variablesToLookFor: [number, number] = [
@@ -184,6 +186,11 @@ function App() {
     variablesToLookFor,
     isStoredState,
   );
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 600);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
   useEffect(() => {
     if (isStoredState) return;
     if (numOfEnemies < previousNumOfEnemies) {
@@ -795,42 +802,69 @@ function App() {
                   {val2 < 0 ? `(${val2})` : val2}
                 </Text>
                 <Text style={[styles.mathText, { color: '#fff' }]}>=</Text>
-                <TextInput
-                  nativeID="answer-input"
-                  style={[
-                    styles.input,
-                    highContrast && highContrastStyles.input,
-                  ]}
-                  onChangeText={handleAnswerChange}
-                  onSubmitEditing={handleSubmit}
-                  onKeyPress={handleKeyDown as any}
-                  value={answer}
-                  ref={submitInputRef}
-                  accessibilityLabel="Enter your answer"
-                />
-              </View>
-              <View style={styles.submitRow}>
-                <TouchableOpacity
-                  style={[
-                    styles.button,
-                    { backgroundColor: activeTheme.buttonColor },
-                    highContrast && highContrastStyles.button,
-                  ]}
-                  testID="submit"
-                  onPress={handleSubmit}
-                  accessibilityLabel="Submit answer"
-                  accessibilityRole="button"
-                >
+                {isMobile ? (
                   <Text
+                    nativeID="answer-input"
                     style={[
-                      styles.buttonText,
-                      highContrast && highContrastStyles.buttonText,
+                      styles.input,
+                      highContrast && highContrastStyles.input,
+                      { lineHeight: 56 },
                     ]}
+                    accessibilityLabel="Current answer"
                   >
-                    Submit
+                    {answer || ' '}
                   </Text>
-                </TouchableOpacity>
+                ) : (
+                  <TextInput
+                    nativeID="answer-input"
+                    style={[
+                      styles.input,
+                      highContrast && highContrastStyles.input,
+                    ]}
+                    onChangeText={handleAnswerChange}
+                    onSubmitEditing={handleSubmit}
+                    onKeyPress={handleKeyDown as any}
+                    value={answer}
+                    ref={submitInputRef}
+                    accessibilityLabel="Enter your answer"
+                  />
+                )}
               </View>
+              {isMobile ? (
+                <View style={styles.submitRow}>
+                  <NumberPad
+                    value={answer}
+                    onChange={handleAnswerChange}
+                    onSubmit={handleSubmit}
+                    showMinus={modeType === 'negative'}
+                    showDecimal={modeType === 'decimals'}
+                    buttonColor={activeTheme.buttonColor}
+                  />
+                </View>
+              ) : (
+                <View style={styles.submitRow}>
+                  <TouchableOpacity
+                    style={[
+                      styles.button,
+                      { backgroundColor: activeTheme.buttonColor },
+                      highContrast && highContrastStyles.button,
+                    ]}
+                    testID="submit"
+                    onPress={handleSubmit}
+                    accessibilityLabel="Submit answer"
+                    accessibilityRole="button"
+                  >
+                    <Text
+                      style={[
+                        styles.buttonText,
+                        highContrast && highContrastStyles.buttonText,
+                      ]}
+                    >
+                      Submit
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              )}
             </View>
           )}
         </View>

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+
+interface NumberPadProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  showMinus?: boolean;
+  showDecimal?: boolean;
+  buttonColor?: string;
+}
+
+function NumberPad({
+  value,
+  onChange,
+  onSubmit,
+  showMinus = false,
+  showDecimal = false,
+  buttonColor = 'rgba(255, 201, 20, 1)',
+}: NumberPadProps) {
+  const handleDigit = (digit: string) => {
+    onChange(value + digit);
+  };
+
+  const handleBackspace = () => {
+    onChange(value.slice(0, -1));
+  };
+
+  const handleMinus = () => {
+    if (value.startsWith('-')) {
+      onChange(value.slice(1));
+    } else {
+      onChange('-' + value);
+    }
+  };
+
+  const handleDecimal = () => {
+    if (!value.includes('.')) {
+      onChange(value + '.');
+    }
+  };
+
+  const needsExtraRow = showMinus || showDecimal;
+
+  return (
+    <View style={padStyles.container} testID="number-pad">
+      {/* Row 1 */}
+      <View style={padStyles.row}>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('1')}
+          activeOpacity={0.7}
+          accessibilityLabel="1"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>1</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('2')}
+          activeOpacity={0.7}
+          accessibilityLabel="2"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>2</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('3')}
+          activeOpacity={0.7}
+          accessibilityLabel="3"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>3</Text>
+        </TouchableOpacity>
+      </View>
+      {/* Row 2 */}
+      <View style={padStyles.row}>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('4')}
+          activeOpacity={0.7}
+          accessibilityLabel="4"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>4</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('5')}
+          activeOpacity={0.7}
+          accessibilityLabel="5"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>5</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('6')}
+          activeOpacity={0.7}
+          accessibilityLabel="6"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>6</Text>
+        </TouchableOpacity>
+      </View>
+      {/* Row 3 */}
+      <View style={padStyles.row}>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('7')}
+          activeOpacity={0.7}
+          accessibilityLabel="7"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>7</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('8')}
+          activeOpacity={0.7}
+          accessibilityLabel="8"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>8</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={padStyles.button}
+          onPress={() => handleDigit('9')}
+          activeOpacity={0.7}
+          accessibilityLabel="9"
+          accessibilityRole="button"
+        >
+          <Text style={padStyles.digitText}>9</Text>
+        </TouchableOpacity>
+      </View>
+      {/* Row 4: varies based on mode */}
+      {needsExtraRow ? (
+        <>
+          <View style={padStyles.row}>
+            {showMinus && (
+              <TouchableOpacity
+                style={padStyles.button}
+                onPress={handleMinus}
+                activeOpacity={0.7}
+                accessibilityLabel="Minus sign"
+                accessibilityRole="button"
+              >
+                <Text style={padStyles.digitText}>{'\u2212'}</Text>
+              </TouchableOpacity>
+            )}
+            {showDecimal && (
+              <TouchableOpacity
+                style={padStyles.button}
+                onPress={handleDecimal}
+                activeOpacity={0.7}
+                accessibilityLabel="Decimal point"
+                accessibilityRole="button"
+              >
+                <Text style={padStyles.digitText}>.</Text>
+              </TouchableOpacity>
+            )}
+            <TouchableOpacity
+              style={padStyles.button}
+              onPress={() => handleDigit('0')}
+              activeOpacity={0.7}
+              accessibilityLabel="0"
+              accessibilityRole="button"
+            >
+              <Text style={padStyles.digitText}>0</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={padStyles.button}
+              onPress={handleBackspace}
+              activeOpacity={0.7}
+              accessibilityLabel="Backspace"
+              accessibilityRole="button"
+            >
+              <Text style={padStyles.digitText}>{'\u2190'}</Text>
+            </TouchableOpacity>
+          </View>
+          <View style={padStyles.row}>
+            <TouchableOpacity
+              style={[padStyles.submitButton, { backgroundColor: buttonColor }]}
+              onPress={onSubmit}
+              activeOpacity={0.7}
+              accessibilityLabel="Submit answer"
+              accessibilityRole="button"
+            >
+              <Text style={padStyles.submitText}>{'\u2713'} Submit</Text>
+            </TouchableOpacity>
+          </View>
+        </>
+      ) : (
+        <View style={padStyles.row}>
+          <TouchableOpacity
+            style={padStyles.button}
+            onPress={handleBackspace}
+            activeOpacity={0.7}
+            accessibilityLabel="Backspace"
+            accessibilityRole="button"
+          >
+            <Text style={padStyles.digitText}>{'\u2190'}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={padStyles.button}
+            onPress={() => handleDigit('0')}
+            activeOpacity={0.7}
+            accessibilityLabel="0"
+            accessibilityRole="button"
+          >
+            <Text style={padStyles.digitText}>0</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[padStyles.button, { backgroundColor: buttonColor }]}
+            onPress={onSubmit}
+            activeOpacity={0.7}
+            accessibilityLabel="Submit answer"
+            accessibilityRole="button"
+          >
+            <Text style={padStyles.digitText}>{'\u2713'}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const padStyles = StyleSheet.create({
+  container: {
+    width: '100%',
+    maxWidth: 280,
+    alignItems: 'center',
+    paddingTop: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  button: {
+    minWidth: 60,
+    minHeight: 60,
+    borderRadius: 12,
+    margin: 4,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  },
+  digitText: {
+    fontSize: 24,
+    color: '#fff',
+    fontFamily: '"Poppins", sans-serif',
+    fontWeight: '600',
+  },
+  submitButton: {
+    minHeight: 60,
+    borderRadius: 12,
+    margin: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  },
+  submitText: {
+    fontSize: 20,
+    color: '#fff',
+    fontFamily: '"Quicksand", sans-serif',
+    fontWeight: '700',
+  },
+});
+
+export default NumberPad;


### PR DESCRIPTION
## Summary
- Adds a `NumberPad` component with large tappable buttons (60x60 min) for mobile users (viewport < 600px)
- On mobile, replaces the `TextInput` with a read-only display and shows the number pad below; desktop keeps the existing text input and submit button
- Supports minus sign toggle for negative mode and decimal point button for decimal mode
- Listens for window resize to dynamically switch between mobile/desktop layouts

Closes #156

## Test plan
- [ ] On mobile (or narrow browser window < 600px), verify number pad appears instead of text input
- [ ] Tap digits and confirm they append to the answer display
- [ ] Tap backspace and confirm it removes the last character
- [ ] In negative mode, verify minus button toggles the sign
- [ ] In decimal mode, verify decimal point button appears and works (only one dot allowed)
- [ ] Tap submit on the number pad and confirm the answer is checked
- [ ] On desktop (>= 600px), verify the standard text input and submit button appear
- [ ] Resize the window across the 600px threshold and confirm the layout switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)