### PR TITLE
feat: add multiple choice answer mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,6 +163,8 @@ function App() {
       correctAttempts,
       totalAnswerTime,
       starsEarned,
+      answerMode,
+      choices,
     },
     dispatch,
   ] = useReducer(reducer, initialState);
@@ -574,6 +576,18 @@ function App() {
                   accessibilityLabel="Select number mode"
                   testID="modeType-selector"
                 />
+                <SegmentedButtonGroup
+                  options={[
+                    { label: 'Type', value: 'type' },
+                    { label: 'Choose', value: 'choose' },
+                  ]}
+                  selectedValue={answerMode}
+                  onSelect={(v) =>
+                    dispatch({ type: TYPES.SET_ANSWER_MODE, payload: v })
+                  }
+                  accessibilityLabel="Select answer mode"
+                  testID="answer-mode-selector"
+                />
               </View>
               <View style={styles.soundControls}>
                 <BackgroundSound url={bgSound} />
@@ -802,35 +816,62 @@ function App() {
                   {val2 < 0 ? `(${val2})` : val2}
                 </Text>
                 <Text style={[styles.mathText, { color: '#fff' }]}>=</Text>
-                {isMobile ? (
-                  <Text
-                    nativeID="answer-input"
-                    style={[
-                      styles.input,
-                      highContrast && highContrastStyles.input,
-                      { lineHeight: 56 },
-                    ]}
-                    accessibilityLabel="Current answer"
-                  >
-                    {answer || ' '}
-                  </Text>
-                ) : (
-                  <TextInput
-                    nativeID="answer-input"
-                    style={[
-                      styles.input,
-                      highContrast && highContrastStyles.input,
-                    ]}
-                    onChangeText={handleAnswerChange}
-                    onSubmitEditing={handleSubmit}
-                    onKeyPress={handleKeyDown as any}
-                    value={answer}
-                    ref={submitInputRef}
-                    accessibilityLabel="Enter your answer"
-                  />
-                )}
+                {answerMode !== 'choose' &&
+                  (isMobile ? (
+                    <Text
+                      nativeID="answer-input"
+                      style={[
+                        styles.input,
+                        highContrast && highContrastStyles.input,
+                        { lineHeight: 56 },
+                      ]}
+                      accessibilityLabel="Current answer"
+                    >
+                      {answer || ' '}
+                    </Text>
+                  ) : (
+                    <TextInput
+                      nativeID="answer-input"
+                      style={[
+                        styles.input,
+                        highContrast && highContrastStyles.input,
+                      ]}
+                      onChangeText={handleAnswerChange}
+                      onSubmitEditing={handleSubmit}
+                      onKeyPress={handleKeyDown as any}
+                      value={answer}
+                      ref={submitInputRef}
+                      accessibilityLabel="Enter your answer"
+                    />
+                  ))}
               </View>
-              {isMobile ? (
+              {answerMode === 'choose' ? (
+                <View style={styles.choiceGrid}>
+                  {choices.map((choice, i) => (
+                    <TouchableOpacity
+                      key={i}
+                      style={[
+                        styles.choiceButton,
+                        { backgroundColor: activeTheme.buttonColor },
+                      ]}
+                      onPress={() => {
+                        dispatch({
+                          type: TYPES.SET_ANSWER,
+                          payload: String(choice),
+                        });
+                        setTimeout(
+                          () => dispatch({ type: TYPES.CHECK_ANSWER }),
+                          100,
+                        );
+                      }}
+                      accessibilityLabel={`Answer ${choice}`}
+                      accessibilityRole="button"
+                    >
+                      <Text style={styles.choiceButtonText}>{choice}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              ) : isMobile ? (
                 <View style={styles.submitRow}>
                   <NumberPad
                     value={answer}
@@ -1016,6 +1057,27 @@ const styles = StyleSheet.create({
     opacity: 0.4,
   },
   mathContainer: { paddingVertical: 16, alignItems: 'center' },
+  choiceGrid: {
+    flexDirection: 'row' as const,
+    flexWrap: 'wrap' as const,
+    justifyContent: 'center' as const,
+    gap: 10,
+    paddingVertical: 8,
+    maxWidth: 300,
+  },
+  choiceButton: {
+    width: '45%' as any,
+    minHeight: 56,
+    borderRadius: 12,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  },
+  choiceButtonText: {
+    fontSize: 24,
+    fontWeight: 'bold' as const,
+    fontFamily: '"Poppins", sans-serif',
+    color: '#fff',
+  },
   mathRow: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/src/AppReducer.test.ts
+++ b/src/AppReducer.test.ts
@@ -7,6 +7,7 @@ import {
   calculateStars,
   getAdaptiveDifficulty,
   getStreakMilestone,
+  generateChoices,
   AppState,
   ActionType,
 } from './AppReducer';
@@ -1155,5 +1156,76 @@ describe('star rating tracking', () => {
     expect(result.won).toBe(true);
     expect(result.starsEarned).toBe(3); // 3/3 correct, avg 3s
     jest.restoreAllMocks();
+  });
+});
+
+describe('generateChoices', () => {
+  it('returns exactly 4 numbers', () => {
+    const choices = generateChoices(10);
+    expect(choices).toHaveLength(4);
+  });
+
+  it('includes the correct answer', () => {
+    for (let i = 0; i < 20; i++) {
+      const correct = Math.floor(Math.random() * 100) - 50;
+      const choices = generateChoices(correct);
+      expect(choices).toContain(correct);
+    }
+  });
+
+  it('contains 4 unique values', () => {
+    for (let i = 0; i < 20; i++) {
+      const choices = generateChoices(42);
+      const unique = new Set(choices);
+      expect(unique.size).toBe(4);
+    }
+  });
+});
+
+describe('answer mode', () => {
+  it('SET_ANSWER_MODE changes answerMode to choose', () => {
+    const state = makeState({ answerMode: 'type' });
+    const result = reducer(state, {
+      type: TYPES.SET_ANSWER_MODE,
+      payload: 'choose',
+    });
+    expect(result.answerMode).toBe('choose');
+    expect(result.choices).toHaveLength(4);
+  });
+
+  it('SET_ANSWER_MODE changes answerMode to type', () => {
+    const state = makeState({ answerMode: 'choose', choices: [1, 2, 3, 4] });
+    const result = reducer(state, {
+      type: TYPES.SET_ANSWER_MODE,
+      payload: 'type',
+    });
+    expect(result.answerMode).toBe('type');
+    expect(result.choices).toEqual([]);
+  });
+
+  it('NEW_PROBLEM generates choices when answerMode is choose', () => {
+    const state = makeState({
+      answerMode: 'choose',
+      val1: 2,
+      val2: 3,
+      operator: '+',
+      mode: 'addition',
+    });
+    const result = reducer(state, { type: TYPES.NEW_PROBLEM });
+    expect(result.choices).toHaveLength(4);
+    const correctAnswer = result.val1 + result.val2;
+    expect(result.choices).toContain(correctAnswer);
+  });
+
+  it('NEW_PROBLEM does not generate choices when answerMode is type', () => {
+    const state = makeState({
+      answerMode: 'type',
+      val1: 2,
+      val2: 3,
+      operator: '+',
+      mode: 'addition',
+    });
+    const result = reducer(state, { type: TYPES.NEW_PROBLEM });
+    expect(result.choices).toEqual([]);
   });
 });

--- a/src/AppReducer.ts
+++ b/src/AppReducer.ts
@@ -27,6 +27,7 @@ export const TYPES = {
   SET_ADAPTIVE: 13,
   DISMISS_TUTORIAL: 14,
   SHOW_TUTORIAL: 15,
+  SET_ANSWER_MODE: 16,
 } as const;
 
 const OPERATORS = {
@@ -85,6 +86,8 @@ export type AppState = {
   correctAttempts: number;
   totalAnswerTime: number;
   starsEarned: number;
+  answerMode: 'type' | 'choose';
+  choices: number[];
 };
 
 export function calculateStars(
@@ -133,6 +136,8 @@ export const initialState: AppState = {
   correctAttempts: 0,
   totalAnswerTime: 0,
   starsEarned: 0,
+  answerMode: 'type',
+  choices: [],
 };
 
 /**
@@ -192,6 +197,44 @@ export function getStreakMilestone(
     default:
       return null;
   }
+}
+
+export function computeAnswer(
+  val1: number,
+  operator: string,
+  val2: number,
+): number {
+  let result: number;
+  switch (operator) {
+    case '+':
+      result = val1 + val2;
+      break;
+    case '-':
+      result = val1 - val2;
+      break;
+    case '*':
+      result = val1 * val2;
+      break;
+    case '/':
+      result = val1 / val2;
+      break;
+    default:
+      result = val1 + val2;
+  }
+  return Number.parseFloat(result.toFixed(2));
+}
+
+export function generateChoices(correctAnswer: number): number[] {
+  const choices = [correctAnswer];
+  const range = Math.max(Math.abs(correctAnswer) * 0.3, 3);
+  while (choices.length < 4) {
+    const offset = Math.floor(Math.random() * range * 2) - range;
+    const distractor = Math.round(correctAnswer + offset);
+    if (distractor !== correctAnswer && !choices.includes(distractor)) {
+      choices.push(distractor);
+    }
+  }
+  return choices.sort(() => Math.random() - 0.5);
 }
 
 export const reducer: Reducer<AppState, ActionType> = (state, action) => {
@@ -285,6 +328,11 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         recentResults: [],
         adaptiveMessage: null,
         maxStreak: state.maxStreak,
+        answerMode: state.answerMode,
+        choices:
+          state.answerMode === 'choose'
+            ? generateChoices(computeAnswer(val[0], state.operator, val[1]))
+            : [],
       };
     }
 
@@ -471,6 +519,10 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         questionStartTime: state.questionStartTime || Date.now(),
         attempts: 0,
         hintLevel: 0,
+        choices:
+          state.answerMode === 'choose'
+            ? generateChoices(computeAnswer(val[0], state.operator, val[1]))
+            : [],
       };
     }
 
@@ -544,6 +596,21 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
       return {
         ...state,
         showTutorial: true,
+      };
+    }
+
+    case TYPES.SET_ANSWER_MODE: {
+      const answerMode = action.payload as 'type' | 'choose';
+      const choices =
+        answerMode === 'choose'
+          ? generateChoices(
+              computeAnswer(state.val1, state.operator, state.val2),
+            )
+          : [];
+      return {
+        ...state,
+        answerMode,
+        choices,
       };
     }
 


### PR DESCRIPTION
## Summary
- Adds a "Choose" answer mode alongside "Type" where kids tap one of 4 answer buttons instead of typing
- New segmented toggle in settings panel to switch between Type and Choose modes
- Generates 4 plausible answer choices (1 correct + 3 close distractors) for each problem
- Choice buttons auto-submit on tap for a faster gameplay experience

Closes #161

## Test plan
- [x] `generateChoices` returns 4 unique numbers including the correct answer
- [x] `SET_ANSWER_MODE` action changes `answerMode` and generates/clears choices
- [x] `NEW_PROBLEM` generates choices when `answerMode` is `choose`, empty array when `type`
- [x] All 117 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)