### PR TITLE
feat: add level/progression system with mastery-based advancement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import { useMsgAfterSubmit } from './hooks';
 import HeroSvg from './components/HeroSvg';
 import Tutorial from './components/Tutorial';
 import NumberPad from './components/NumberPad';
+import LevelSelect from './components/LevelSelect';
+import { Level } from './levels';
 import bgSound from './assets/music/background-music.mp3';
 import BackgroundSound from './components/BackgroundSound';
 import {
@@ -165,6 +167,9 @@ function App() {
       starsEarned,
       answerMode,
       choices,
+      currentLevel,
+      levelProgress,
+      gameScreen,
     },
     dispatch,
   ] = useReducer(reducer, initialState);
@@ -231,6 +236,13 @@ function App() {
     prevHintLevelRef.current = hintLevel;
   }, [hintLevel]);
 
+  // Complete level on victory
+  useEffect(() => {
+    if (won && currentLevel && gameScreen === 'playing') {
+      dispatch({ type: TYPES.COMPLETE_LEVEL });
+    }
+  }, [won, currentLevel, gameScreen]);
+
   // Victory celebration confetti + fanfare
   useEffect(() => {
     if (!won) return;
@@ -292,6 +304,18 @@ function App() {
   const handleShowTutorial = useCallback(() => {
     dispatch({ type: TYPES.SHOW_TUTORIAL });
   }, [dispatch]);
+  const handleSelectLevel = useCallback(
+    (level: Level) => {
+      dispatch({ type: TYPES.SELECT_LEVEL, payload: level });
+    },
+    [dispatch],
+  );
+  const handleFreePlay = useCallback(() => {
+    dispatch({ type: TYPES.PLAY_FREE });
+  }, [dispatch]);
+  const handleBackToLevels = useCallback(() => {
+    dispatch({ type: TYPES.BACK_TO_LEVELS });
+  }, [dispatch]);
   const handleSubmit = useCallback(() => {
     dispatch({ type: TYPES.CHECK_ANSWER });
     setTimeout(() => {
@@ -339,6 +363,7 @@ function App() {
         modeType,
         previousNumOfEnemies,
         hasSeenTutorial,
+        levelProgress,
       }),
     );
   }, [
@@ -353,6 +378,7 @@ function App() {
     modeType,
     previousNumOfEnemies,
     hasSeenTutorial,
+    levelProgress,
   ]);
   const submitMsgText = isErrorMessage
     ? highContrast
@@ -468,6 +494,17 @@ function App() {
               Battle Math
             </Text>
             <View style={styles.topBarRight}>
+              {gameScreen !== 'levelSelect' && (
+                <TouchableOpacity
+                  onPress={handleBackToLevels}
+                  style={styles.levelsButton}
+                  accessibilityLabel="Back to level select"
+                  accessibilityRole="button"
+                  testID="levels-button"
+                >
+                  <Text style={styles.levelsButtonText}>{'\u2630'}</Text>
+                </TouchableOpacity>
+              )}
               <TouchableOpacity
                 onPress={() => setShowSettings(!showSettings)}
                 style={styles.gearButton}
@@ -492,67 +529,78 @@ function App() {
           </View>
 
           {/* === SCORE BAR === */}
-          <View
-            style={[styles.scoreBar, styles.cardPanel, streakGlowStyle]}
-            accessibilityLiveRegion="polite"
-          >
-            <Text
-              style={[styles.timerText, { color: timerColor }]}
-              testID="timer"
-            >{`\u23F1 ${timeLeft}s`}</Text>
-            <Text
-              style={[styles.scoreText, { color: '#fff' }]}
-              testID="score"
-            >{`Score: ${score}`}</Text>
-            <Text
-              style={[styles.bestScoreText, { color: '#fff' }]}
-              testID="best-score"
-            >{`Best: ${bestScore}`}</Text>
-            {showPoints && lastPointsEarned != null && (
+          {gameScreen !== 'levelSelect' && (
+            <View
+              style={[styles.scoreBar, styles.cardPanel, streakGlowStyle]}
+              accessibilityLiveRegion="polite"
+            >
               <Text
-                style={[
-                  styles.pointsEarned,
-                  {
-                    color: lastPointsEarned > 0 ? '#4caf50' : '#f44336',
-                    animationName: 'floatUp',
-                    animationDuration: '1.5s',
-                    animationFillMode: 'forwards',
-                  } as any,
-                ]}
-                testID="points-earned"
-              >{`+${lastPointsEarned}`}</Text>
-            )}
-            {streak >= 3 && (
+                style={[styles.timerText, { color: timerColor }]}
+                testID="timer"
+              >{`\u23F1 ${timeLeft}s`}</Text>
               <Text
-                style={[
-                  styles.streakText,
-                  streak >= 10
-                    ? styles.streakLegendary
-                    : streak >= 5
-                      ? styles.streakFire
-                      : undefined,
-                ]}
-                testID="streak-counter"
-              >{`\uD83D\uDD25 \u00D7${streak}`}</Text>
-            )}
-            {streakLabel && (
+                style={[styles.scoreText, { color: '#fff' }]}
+                testID="score"
+              >{`Score: ${score}`}</Text>
               <Text
-                style={[
-                  styles.streakMilestone,
-                  {
-                    animationName: 'victoryBounce',
-                    animationDuration: '0.5s',
-                    animationFillMode: 'forwards',
-                  } as any,
-                ]}
-              >
-                {streakLabel}
-              </Text>
-            )}
-          </View>
+                style={[styles.bestScoreText, { color: '#fff' }]}
+                testID="best-score"
+              >{`Best: ${bestScore}`}</Text>
+              {showPoints && lastPointsEarned != null && (
+                <Text
+                  style={[
+                    styles.pointsEarned,
+                    {
+                      color: lastPointsEarned > 0 ? '#4caf50' : '#f44336',
+                      animationName: 'floatUp',
+                      animationDuration: '1.5s',
+                      animationFillMode: 'forwards',
+                    } as any,
+                  ]}
+                  testID="points-earned"
+                >{`+${lastPointsEarned}`}</Text>
+              )}
+              {streak >= 3 && (
+                <Text
+                  style={[
+                    styles.streakText,
+                    streak >= 10
+                      ? styles.streakLegendary
+                      : streak >= 5
+                        ? styles.streakFire
+                        : undefined,
+                  ]}
+                  testID="streak-counter"
+                >{`\uD83D\uDD25 \u00D7${streak}`}</Text>
+              )}
+              {streakLabel && (
+                <Text
+                  style={[
+                    styles.streakMilestone,
+                    {
+                      animationName: 'victoryBounce',
+                      animationDuration: '0.5s',
+                      animationFillMode: 'forwards',
+                    } as any,
+                  ]}
+                >
+                  {streakLabel}
+                </Text>
+              )}
+            </View>
+          )}
+
+          {/* === LEVEL SELECT SCREEN === */}
+          {gameScreen === 'levelSelect' && (
+            <LevelSelect
+              progress={levelProgress}
+              onSelectLevel={handleSelectLevel}
+              onFreePlay={handleFreePlay}
+            />
+          )}
 
           {/* === COLLAPSIBLE SETTINGS === */}
-          {showSettings && (
+          {gameScreen !== 'levelSelect' && showSettings && (
             <View style={[styles.cardPanel, styles.settingsPanel]}>
               <View style={styles.pickerContainer}>
                 <SegmentedButtonGroup
@@ -632,281 +680,300 @@ function App() {
               </View>
             </View>
           )}
-          <View style={styles.battlefield}>
-            <View style={styles.heroContainer}>
-              <View nativeID="hero" accessibilityLabel="Your hero character">
-                <Image
-                  source={won ? heroImages.victory : heroImages[heroAnim]}
-                  style={[
-                    styles.characterImage,
-                    heroAnimStyle[heroAnim] as any,
-                  ]}
-                  accessibilityLabel="Hero"
-                />
-              </View>
-            </View>
-            <View style={styles.enemiesContainer}>
-              {[...Array(numOfEnemies)].map((_, i) => (
-                <View
-                  testID="enemies"
-                  key={i}
-                  style={
-                    defeatingEnemy && i === numOfEnemies - 1
-                      ? ({
-                          animationName: 'enemyDefeat',
-                          animationDuration: '0.5s',
-                          animationFillMode: 'forwards',
-                        } as any)
-                      : undefined
-                  }
-                >
-                  <Image
-                    source={enemyImages[mode] || enemyImages.addition}
-                    style={[
-                      styles.characterImage,
-                      defeatingEnemy && i === numOfEnemies - 1
-                        ? undefined
-                        : newEnemyIndex === i
+          {gameScreen !== 'levelSelect' && (
+            <>
+              <View style={styles.battlefield}>
+                <View style={styles.heroContainer}>
+                  <View
+                    nativeID="hero"
+                    accessibilityLabel="Your hero character"
+                  >
+                    <Image
+                      source={won ? heroImages.victory : heroImages[heroAnim]}
+                      style={[
+                        styles.characterImage,
+                        heroAnimStyle[heroAnim] as any,
+                      ]}
+                      accessibilityLabel="Hero"
+                    />
+                  </View>
+                </View>
+                <View style={styles.enemiesContainer}>
+                  {[...Array(numOfEnemies)].map((_, i) => (
+                    <View
+                      testID="enemies"
+                      key={i}
+                      style={
+                        defeatingEnemy && i === numOfEnemies - 1
                           ? ({
-                              animationName: 'enemyEntrance',
+                              animationName: 'enemyDefeat',
                               animationDuration: '0.5s',
                               animationFillMode: 'forwards',
                             } as any)
-                          : ({
-                              animationName: 'enemySway',
-                              animationDuration: '1.5s',
-                              animationIterationCount: 'infinite',
-                              animationTimingFunction: 'ease-in-out',
-                              animationDelay: `${i * 0.3}s`,
-                            } as any),
-                    ]}
-                    accessibilityLabel={`Enemy ${i + 1}`}
-                  />
+                          : undefined
+                      }
+                    >
+                      <Image
+                        source={enemyImages[mode] || enemyImages.addition}
+                        style={[
+                          styles.characterImage,
+                          defeatingEnemy && i === numOfEnemies - 1
+                            ? undefined
+                            : newEnemyIndex === i
+                              ? ({
+                                  animationName: 'enemyEntrance',
+                                  animationDuration: '0.5s',
+                                  animationFillMode: 'forwards',
+                                } as any)
+                              : ({
+                                  animationName: 'enemySway',
+                                  animationDuration: '1.5s',
+                                  animationIterationCount: 'infinite',
+                                  animationTimingFunction: 'ease-in-out',
+                                  animationDelay: `${i * 0.3}s`,
+                                } as any),
+                        ]}
+                        accessibilityLabel={`Enemy ${i + 1}`}
+                      />
+                    </View>
+                  ))}
                 </View>
-              ))}
-            </View>
-          </View>
-          {/* === ATTEMPT HEARTS === */}
-          {!won && (
-            <View style={styles.heartsContainer} testID="hearts-container">
-              {[0, 1, 2].map((i) => (
-                <Text
-                  key={i}
+              </View>
+              {/* === ATTEMPT HEARTS === */}
+              {!won && (
+                <View style={styles.heartsContainer} testID="hearts-container">
+                  {[0, 1, 2].map((i) => (
+                    <Text
+                      key={i}
+                      style={[
+                        styles.heart,
+                        i < 3 - attempts ? styles.heartFull : styles.heartEmpty,
+                        i === 3 - attempts && attempts > 0 && hintLevel > 0
+                          ? ({
+                              animationName: 'heartBreak',
+                              animationDuration: '0.5s',
+                            } as any)
+                          : undefined,
+                      ]}
+                      accessibilityLabel={
+                        i < 3 - attempts ? 'Heart full' : 'Heart empty'
+                      }
+                    >
+                      {i < 3 - attempts ? '\u2764\uFE0F' : '\uD83D\uDDA4'}
+                    </Text>
+                  ))}
+                </View>
+              )}
+              {won ? (
+                <View style={[styles.cardPanel, styles.victoryPanel]}>
+                  <Text
+                    style={[
+                      styles.victoryText,
+                      {
+                        animationName: 'victoryBounce',
+                        animationDuration: '0.8s',
+                        animationFillMode: 'forwards',
+                      } as any,
+                    ]}
+                    accessibilityRole="text"
+                  >
+                    Victory!
+                  </Text>
+                  <View
+                    style={styles.starsContainer}
+                    nativeID="stars-container"
+                  >
+                    {[0, 1, 2].map((i) => (
+                      <Text
+                        key={i}
+                        style={[
+                          styles.star,
+                          i < starsEarned
+                            ? ({
+                                color: '#FFD93D',
+                                animationName: 'starEarned',
+                                animationDuration: '0.5s',
+                                animationDelay: `${i * 0.5}s`,
+                                animationFillMode: 'both',
+                              } as any)
+                            : { color: '#666' },
+                        ]}
+                      >
+                        {i < starsEarned ? '\u2605' : '\u2606'}
+                      </Text>
+                    ))}
+                  </View>
+                  <Text
+                    style={styles.victoryStats}
+                    accessibilityRole="text"
+                  >{`Accuracy: ${totalAttempts > 0 ? Math.round((correctAttempts / totalAttempts) * 100) : 0}%`}</Text>
+                  <Text
+                    style={styles.victoryScore}
+                    accessibilityRole="text"
+                  >{`Final Score: ${score}`}</Text>
+                  <Text
+                    style={styles.victoryBest}
+                    accessibilityRole="text"
+                  >{`Best Score: ${bestScore}`}</Text>
+                  {maxStreak >= 3 && (
+                    <Text
+                      style={styles.victoryBest}
+                      accessibilityRole="text"
+                    >{`Best Streak: \uD83D\uDD25 \u00D7${maxStreak}`}</Text>
+                  )}
+                  <TouchableOpacity
+                    onPress={handleRestart}
+                    style={[
+                      styles.restartButton,
+                      {
+                        backgroundColor: activeTheme.buttonColor,
+                        animationName: 'pulse',
+                        animationDuration: '1.5s',
+                        animationIterationCount: 'infinite',
+                      } as any,
+                    ]}
+                    accessibilityLabel="Play again"
+                    accessibilityRole="button"
+                  >
+                    <Text style={styles.restartButtonText}>Play Again</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={handleBackToLevels}
+                    style={styles.backToLevelsButton}
+                    accessibilityLabel="Back to level select"
+                    accessibilityRole="button"
+                    testID="back-to-levels"
+                  >
+                    <Text style={styles.backToLevelsText}>Back to Levels</Text>
+                  </TouchableOpacity>
+                </View>
+              ) : (
+                <View
                   style={[
-                    styles.heart,
-                    i < 3 - attempts ? styles.heartFull : styles.heartEmpty,
-                    i === 3 - attempts && attempts > 0 && hintLevel > 0
+                    styles.mathContainer,
+                    styles.cardPanel,
+                    shaking
                       ? ({
-                          animationName: 'heartBreak',
+                          animationName: 'shake',
                           animationDuration: '0.5s',
                         } as any)
                       : undefined,
                   ]}
-                  accessibilityLabel={
-                    i < 3 - attempts ? 'Heart full' : 'Heart empty'
-                  }
                 >
-                  {i < 3 - attempts ? '\u2764\uFE0F' : '\uD83D\uDDA4'}
-                </Text>
-              ))}
-            </View>
-          )}
-          {won ? (
-            <View style={[styles.cardPanel, styles.victoryPanel]}>
-              <Text
-                style={[
-                  styles.victoryText,
-                  {
-                    animationName: 'victoryBounce',
-                    animationDuration: '0.8s',
-                    animationFillMode: 'forwards',
-                  } as any,
-                ]}
-                accessibilityRole="text"
-              >
-                Victory!
-              </Text>
-              <View style={styles.starsContainer} nativeID="stars-container">
-                {[0, 1, 2].map((i) => (
-                  <Text
-                    key={i}
-                    style={[
-                      styles.star,
-                      i < starsEarned
-                        ? ({
-                            color: '#FFD93D',
-                            animationName: 'starEarned',
-                            animationDuration: '0.5s',
-                            animationDelay: `${i * 0.5}s`,
-                            animationFillMode: 'both',
-                          } as any)
-                        : { color: '#666' },
-                    ]}
-                  >
-                    {i < starsEarned ? '\u2605' : '\u2606'}
-                  </Text>
-                ))}
-              </View>
-              <Text
-                style={styles.victoryStats}
-                accessibilityRole="text"
-              >{`Accuracy: ${totalAttempts > 0 ? Math.round((correctAttempts / totalAttempts) * 100) : 0}%`}</Text>
-              <Text
-                style={styles.victoryScore}
-                accessibilityRole="text"
-              >{`Final Score: ${score}`}</Text>
-              <Text
-                style={styles.victoryBest}
-                accessibilityRole="text"
-              >{`Best Score: ${bestScore}`}</Text>
-              {maxStreak >= 3 && (
-                <Text
-                  style={styles.victoryBest}
-                  accessibilityRole="text"
-                >{`Best Streak: \uD83D\uDD25 \u00D7${maxStreak}`}</Text>
-              )}
-              <TouchableOpacity
-                onPress={handleRestart}
-                style={[
-                  styles.restartButton,
-                  {
-                    backgroundColor: activeTheme.buttonColor,
-                    animationName: 'pulse',
-                    animationDuration: '1.5s',
-                    animationIterationCount: 'infinite',
-                  } as any,
-                ]}
-                accessibilityLabel="Play again"
-                accessibilityRole="button"
-              >
-                <Text style={styles.restartButtonText}>Play Again</Text>
-              </TouchableOpacity>
-            </View>
-          ) : (
-            <View
-              style={[
-                styles.mathContainer,
-                styles.cardPanel,
-                shaking
-                  ? ({
-                      animationName: 'shake',
-                      animationDuration: '0.5s',
-                    } as any)
-                  : undefined,
-              ]}
-            >
-              {submitMessageBlock}
-              <View style={styles.mathRow}>
-                <Text
-                  nativeID="val1"
-                  style={[styles.mathText, { color: '#fff' }]}
-                >
-                  {val1 < 0 ? `(${val1})` : val1}
-                </Text>
-                <Text
-                  nativeID="operator"
-                  style={[styles.mathText, { color: '#fff' }]}
-                >
-                  {displayOperator(operator)}
-                </Text>
-                <Text
-                  nativeID="val2"
-                  style={[styles.mathText, { color: '#fff' }]}
-                >
-                  {val2 < 0 ? `(${val2})` : val2}
-                </Text>
-                <Text style={[styles.mathText, { color: '#fff' }]}>=</Text>
-                {answerMode !== 'choose' &&
-                  (isMobile ? (
+                  {submitMessageBlock}
+                  <View style={styles.mathRow}>
                     <Text
-                      nativeID="answer-input"
-                      style={[
-                        styles.input,
-                        highContrast && highContrastStyles.input,
-                        { lineHeight: 56 },
-                      ]}
-                      accessibilityLabel="Current answer"
+                      nativeID="val1"
+                      style={[styles.mathText, { color: '#fff' }]}
                     >
-                      {answer || ' '}
+                      {val1 < 0 ? `(${val1})` : val1}
                     </Text>
+                    <Text
+                      nativeID="operator"
+                      style={[styles.mathText, { color: '#fff' }]}
+                    >
+                      {displayOperator(operator)}
+                    </Text>
+                    <Text
+                      nativeID="val2"
+                      style={[styles.mathText, { color: '#fff' }]}
+                    >
+                      {val2 < 0 ? `(${val2})` : val2}
+                    </Text>
+                    <Text style={[styles.mathText, { color: '#fff' }]}>=</Text>
+                    {answerMode !== 'choose' &&
+                      (isMobile ? (
+                        <Text
+                          nativeID="answer-input"
+                          style={[
+                            styles.input,
+                            highContrast && highContrastStyles.input,
+                            { lineHeight: 56 },
+                          ]}
+                          accessibilityLabel="Current answer"
+                        >
+                          {answer || ' '}
+                        </Text>
+                      ) : (
+                        <TextInput
+                          nativeID="answer-input"
+                          style={[
+                            styles.input,
+                            highContrast && highContrastStyles.input,
+                          ]}
+                          onChangeText={handleAnswerChange}
+                          onSubmitEditing={handleSubmit}
+                          onKeyPress={handleKeyDown as any}
+                          value={answer}
+                          ref={submitInputRef}
+                          accessibilityLabel="Enter your answer"
+                        />
+                      ))}
+                  </View>
+                  {answerMode === 'choose' ? (
+                    <View style={styles.choiceGrid}>
+                      {choices.map((choice, i) => (
+                        <TouchableOpacity
+                          key={i}
+                          style={[
+                            styles.choiceButton,
+                            { backgroundColor: activeTheme.buttonColor },
+                          ]}
+                          onPress={() => {
+                            dispatch({
+                              type: TYPES.SET_ANSWER,
+                              payload: String(choice),
+                            });
+                            setTimeout(
+                              () => dispatch({ type: TYPES.CHECK_ANSWER }),
+                              100,
+                            );
+                          }}
+                          accessibilityLabel={`Answer ${choice}`}
+                          accessibilityRole="button"
+                        >
+                          <Text style={styles.choiceButtonText}>{choice}</Text>
+                        </TouchableOpacity>
+                      ))}
+                    </View>
+                  ) : isMobile ? (
+                    <View style={styles.submitRow}>
+                      <NumberPad
+                        value={answer}
+                        onChange={handleAnswerChange}
+                        onSubmit={handleSubmit}
+                        showMinus={modeType === 'negative'}
+                        showDecimal={modeType === 'decimals'}
+                        buttonColor={activeTheme.buttonColor}
+                      />
+                    </View>
                   ) : (
-                    <TextInput
-                      nativeID="answer-input"
-                      style={[
-                        styles.input,
-                        highContrast && highContrastStyles.input,
-                      ]}
-                      onChangeText={handleAnswerChange}
-                      onSubmitEditing={handleSubmit}
-                      onKeyPress={handleKeyDown as any}
-                      value={answer}
-                      ref={submitInputRef}
-                      accessibilityLabel="Enter your answer"
-                    />
-                  ))}
-              </View>
-              {answerMode === 'choose' ? (
-                <View style={styles.choiceGrid}>
-                  {choices.map((choice, i) => (
-                    <TouchableOpacity
-                      key={i}
-                      style={[
-                        styles.choiceButton,
-                        { backgroundColor: activeTheme.buttonColor },
-                      ]}
-                      onPress={() => {
-                        dispatch({
-                          type: TYPES.SET_ANSWER,
-                          payload: String(choice),
-                        });
-                        setTimeout(
-                          () => dispatch({ type: TYPES.CHECK_ANSWER }),
-                          100,
-                        );
-                      }}
-                      accessibilityLabel={`Answer ${choice}`}
-                      accessibilityRole="button"
-                    >
-                      <Text style={styles.choiceButtonText}>{choice}</Text>
-                    </TouchableOpacity>
-                  ))}
-                </View>
-              ) : isMobile ? (
-                <View style={styles.submitRow}>
-                  <NumberPad
-                    value={answer}
-                    onChange={handleAnswerChange}
-                    onSubmit={handleSubmit}
-                    showMinus={modeType === 'negative'}
-                    showDecimal={modeType === 'decimals'}
-                    buttonColor={activeTheme.buttonColor}
-                  />
-                </View>
-              ) : (
-                <View style={styles.submitRow}>
-                  <TouchableOpacity
-                    style={[
-                      styles.button,
-                      { backgroundColor: activeTheme.buttonColor },
-                      highContrast && highContrastStyles.button,
-                    ]}
-                    testID="submit"
-                    onPress={handleSubmit}
-                    accessibilityLabel="Submit answer"
-                    accessibilityRole="button"
-                  >
-                    <Text
-                      style={[
-                        styles.buttonText,
-                        highContrast && highContrastStyles.buttonText,
-                      ]}
-                    >
-                      Submit
-                    </Text>
-                  </TouchableOpacity>
+                    <View style={styles.submitRow}>
+                      <TouchableOpacity
+                        style={[
+                          styles.button,
+                          { backgroundColor: activeTheme.buttonColor },
+                          highContrast && highContrastStyles.button,
+                        ]}
+                        testID="submit"
+                        onPress={handleSubmit}
+                        accessibilityLabel="Submit answer"
+                        accessibilityRole="button"
+                      >
+                        <Text
+                          style={[
+                            styles.buttonText,
+                            highContrast && highContrastStyles.buttonText,
+                          ]}
+                        >
+                          Submit
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+                  )}
                 </View>
               )}
-            </View>
+            </>
           )}
         </View>
       </View>
@@ -1274,6 +1341,36 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontFamily: '"Quicksand", sans-serif',
     fontWeight: '700',
+  },
+  levelsButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  },
+  levelsButtonText: {
+    fontSize: 22,
+    color: '#fff',
+  },
+  backToLevelsButton: {
+    width: '100%',
+    maxWidth: 280,
+    height: 48,
+    borderRadius: 12,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+    marginTop: 8,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    borderWidth: 2,
+    borderColor: 'rgba(255, 255, 255, 0.4)',
+  },
+  backToLevelsText: {
+    color: '#fff',
+    fontSize: 18,
+    fontFamily: '"Quicksand", sans-serif',
+    fontWeight: '600' as const,
   },
   enemyCount: { paddingVertical: 4 },
   enemyCountText: {

--- a/src/AppReducer.test.ts
+++ b/src/AppReducer.test.ts
@@ -11,6 +11,7 @@ import {
   AppState,
   ActionType,
 } from './AppReducer';
+import { LEVELS } from './levels';
 
 // Helper to create a state with overrides
 const makeState = (overrides: Partial<AppState> = {}): AppState => ({
@@ -1179,6 +1180,129 @@ describe('generateChoices', () => {
       const unique = new Set(choices);
       expect(unique.size).toBe(4);
     }
+  });
+});
+
+describe('SELECT_LEVEL', () => {
+  it('sets mode, difficulty, and enemyCount from level', () => {
+    const level = LEVELS[0]; // Addition 1, easy, 5 enemies
+    const state = makeState();
+    const result = reducer(state, {
+      type: TYPES.SELECT_LEVEL,
+      payload: level,
+    });
+
+    expect(result.mode).toBe('addition');
+    expect(result.difficulty).toBe('easy');
+    expect(result.numOfEnemies).toBe(5);
+    expect(result.currentLevel).toBe(level);
+    expect(result.gameScreen).toBe('playing');
+    expect(result.operator).toBe('+');
+  });
+
+  it('sets subtraction mode for subtraction level', () => {
+    const level = LEVELS[3]; // Subtraction 1
+    const state = makeState();
+    const result = reducer(state, {
+      type: TYPES.SELECT_LEVEL,
+      payload: level,
+    });
+
+    expect(result.mode).toBe('subtraction');
+    expect(result.operator).toBe('-');
+  });
+
+  it('resets score and attempts', () => {
+    const level = LEVELS[0];
+    const state = makeState({ score: 50, totalAttempts: 10 });
+    const result = reducer(state, {
+      type: TYPES.SELECT_LEVEL,
+      payload: level,
+    });
+
+    expect(result.score).toBe(0);
+    expect(result.totalAttempts).toBe(0);
+    expect(result.won).toBe(false);
+  });
+});
+
+describe('COMPLETE_LEVEL', () => {
+  it('records progress when a level is completed', () => {
+    const level = LEVELS[0];
+    const state = makeState({
+      currentLevel: level,
+      gameScreen: 'playing',
+      won: true,
+      score: 30,
+      totalAttempts: 5,
+      correctAttempts: 5,
+      totalAnswerTime: 20000,
+      starsEarned: 3,
+    });
+    const result = reducer(state, { type: TYPES.COMPLETE_LEVEL });
+
+    expect(result.gameScreen).toBe('victory');
+    expect(result.levelProgress[1]).toBeDefined();
+    expect(result.levelProgress[1].completed).toBe(true);
+    expect(result.levelProgress[1].stars).toBe(3);
+    expect(result.levelProgress[1].bestScore).toBe(30);
+  });
+
+  it('keeps best stars from previous attempt', () => {
+    const level = LEVELS[0];
+    const state = makeState({
+      currentLevel: level,
+      gameScreen: 'playing',
+      won: true,
+      score: 10,
+      totalAttempts: 5,
+      correctAttempts: 3,
+      starsEarned: 1,
+      levelProgress: {
+        1: {
+          levelId: 1,
+          completed: true,
+          stars: 3,
+          bestScore: 50,
+          bestAccuracy: 100,
+        },
+      },
+    });
+    const result = reducer(state, { type: TYPES.COMPLETE_LEVEL });
+
+    expect(result.levelProgress[1].stars).toBe(3); // kept from previous
+    expect(result.levelProgress[1].bestScore).toBe(50); // kept from previous
+  });
+
+  it('does nothing when no current level', () => {
+    const state = makeState({ currentLevel: null });
+    const result = reducer(state, { type: TYPES.COMPLETE_LEVEL });
+    expect(result).toBe(state);
+  });
+});
+
+describe('BACK_TO_LEVELS', () => {
+  it('returns to level select', () => {
+    const state = makeState({
+      gameScreen: 'victory',
+      currentLevel: LEVELS[0],
+      won: true,
+    });
+    const result = reducer(state, { type: TYPES.BACK_TO_LEVELS });
+
+    expect(result.gameScreen).toBe('levelSelect');
+    expect(result.currentLevel).toBeNull();
+    expect(result.won).toBe(false);
+  });
+});
+
+describe('PLAY_FREE', () => {
+  it('sets gameScreen to playing with no level', () => {
+    const state = makeState({ gameScreen: 'levelSelect' });
+    const result = reducer(state, { type: TYPES.PLAY_FREE });
+
+    expect(result.gameScreen).toBe('playing');
+    expect(result.currentLevel).toBeNull();
   });
 });
 

--- a/src/AppReducer.ts
+++ b/src/AppReducer.ts
@@ -1,4 +1,5 @@
 import { Reducer } from 'react';
+import { Level, LevelProgress } from './levels';
 
 export function randomNumberGenerator(
   min: number,
@@ -28,6 +29,10 @@ export const TYPES = {
   DISMISS_TUTORIAL: 14,
   SHOW_TUTORIAL: 15,
   SET_ANSWER_MODE: 16,
+  SELECT_LEVEL: 17,
+  COMPLETE_LEVEL: 18,
+  BACK_TO_LEVELS: 19,
+  PLAY_FREE: 20,
 } as const;
 
 const OPERATORS = {
@@ -88,6 +93,9 @@ export type AppState = {
   starsEarned: number;
   answerMode: 'type' | 'choose';
   choices: number[];
+  currentLevel: Level | null;
+  levelProgress: Record<number, LevelProgress>;
+  gameScreen: 'levelSelect' | 'playing' | 'victory';
 };
 
 export function calculateStars(
@@ -138,6 +146,9 @@ export const initialState: AppState = {
   starsEarned: 0,
   answerMode: 'type',
   choices: [],
+  currentLevel: null,
+  levelProgress: {},
+  gameScreen: 'levelSelect',
 };
 
 /**
@@ -333,6 +344,15 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
           state.answerMode === 'choose'
             ? generateChoices(computeAnswer(val[0], state.operator, val[1]))
             : [],
+        currentLevel: state.currentLevel,
+        levelProgress: state.levelProgress,
+        gameScreen: 'playing',
+        numOfEnemies: state.currentLevel
+          ? state.currentLevel.enemyCount
+          : initialState.numOfEnemies,
+        previousNumOfEnemies: state.currentLevel
+          ? state.currentLevel.enemyCount
+          : initialState.numOfEnemies,
       };
     }
 
@@ -614,6 +634,105 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
       };
     }
 
+    case TYPES.SELECT_LEVEL: {
+      const level = action.payload as Level;
+      const op =
+        OPERATORS[level.world as keyof typeof OPERATORS] || OPERATORS.addition;
+      const mode = level.world as keyof typeof OPERATORS;
+      const difficulty = level.difficulty as keyof typeof DIFFICULTIES;
+      let val = randomNumber(difficulty, mode);
+      const choices =
+        state.answerMode === 'choose'
+          ? generateChoices(computeAnswer(val[0], op, val[1]))
+          : [];
+      return {
+        ...initialState,
+        mode,
+        difficulty,
+        modeType: state.modeType,
+        operator: op,
+        val1: val[0],
+        val2: val[1],
+        numOfEnemies: level.enemyCount,
+        previousNumOfEnemies: level.enemyCount,
+        currentLevel: level,
+        levelProgress: state.levelProgress,
+        gameScreen: 'playing',
+        questionStartTime: Date.now(),
+        soundEnabled: state.soundEnabled,
+        highContrast: state.highContrast,
+        answerMode: state.answerMode,
+        bestScore: state.bestScore,
+        choices,
+        hasSeenTutorial: state.hasSeenTutorial,
+      };
+    }
+
+    case TYPES.COMPLETE_LEVEL: {
+      if (!state.currentLevel) return state;
+      const accuracy =
+        state.totalAttempts > 0
+          ? state.correctAttempts / state.totalAttempts
+          : 0;
+      const prevProgress = state.levelProgress[state.currentLevel.id];
+      const newStars = state.starsEarned;
+      const newProgress: LevelProgress = {
+        levelId: state.currentLevel.id,
+        completed: true,
+        stars: Math.max(newStars, prevProgress?.stars ?? 0),
+        bestScore: Math.max(state.score, prevProgress?.bestScore ?? 0),
+        bestAccuracy: Math.max(
+          Math.round(accuracy * 100),
+          prevProgress?.bestAccuracy ?? 0,
+        ),
+      };
+      const updatedProgress = {
+        ...state.levelProgress,
+        [state.currentLevel.id]: newProgress,
+      };
+      return {
+        ...state,
+        levelProgress: updatedProgress,
+        gameScreen: 'victory',
+      };
+    }
+
+    case TYPES.BACK_TO_LEVELS: {
+      return {
+        ...state,
+        currentLevel: null,
+        gameScreen: 'levelSelect',
+        won: false,
+      };
+    }
+
+    case TYPES.PLAY_FREE: {
+      let val = randomNumber();
+      const choices =
+        state.answerMode === 'choose'
+          ? generateChoices(computeAnswer(val[0], state.operator, val[1]))
+          : [];
+      return {
+        ...initialState,
+        mode: state.mode,
+        difficulty: state.difficulty,
+        modeType: state.modeType,
+        operator: state.operator,
+        val1: val[0],
+        val2: val[1],
+        currentLevel: null,
+        levelProgress: state.levelProgress,
+        gameScreen: 'playing',
+        questionStartTime: Date.now(),
+        soundEnabled: state.soundEnabled,
+        highContrast: state.highContrast,
+        answerMode: state.answerMode,
+        bestScore: state.bestScore,
+        choices,
+        hasSeenTutorial: state.hasSeenTutorial,
+      };
+    }
+
     case TYPES.RESTORE_STATE: {
       const storedState = action.payload as Partial<AppState>;
       return {
@@ -622,6 +741,9 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         isStoredState: true,
         showTutorial: storedState.hasSeenTutorial ? false : true,
         hasSeenTutorial: storedState.hasSeenTutorial ?? false,
+        levelProgress: storedState.levelProgress ?? {},
+        gameScreen: 'levelSelect',
+        currentLevel: null,
       };
     }
 

--- a/src/components/LevelSelect.tsx
+++ b/src/components/LevelSelect.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { Level, LevelProgress, LEVELS, isLevelUnlocked } from '../levels';
+
+interface LevelSelectProps {
+  progress: Record<number, LevelProgress>;
+  onSelectLevel: (level: Level) => void;
+  onFreePlay: () => void;
+}
+
+const WORLD_COLORS: Record<string, string> = {
+  addition: 'rgba(255, 201, 20, 0.85)',
+  subtraction: 'rgba(79, 195, 247, 0.85)',
+  multiplication: 'rgba(156, 100, 220, 0.85)',
+  division: 'rgba(77, 182, 172, 0.85)',
+};
+
+const WORLD_HEADER_COLORS: Record<string, string> = {
+  addition: '#FFD93D',
+  subtraction: '#4FC3F7',
+  multiplication: '#9C64DC',
+  division: '#4DB6AC',
+};
+
+function getWorlds(): { worldName: string; world: string; levels: Level[] }[] {
+  const worldMap = new Map<
+    string,
+    { worldName: string; world: string; levels: Level[] }
+  >();
+  for (const level of LEVELS) {
+    if (!worldMap.has(level.world)) {
+      worldMap.set(level.world, {
+        worldName: level.worldName,
+        world: level.world,
+        levels: [],
+      });
+    }
+    worldMap.get(level.world)!.levels.push(level);
+  }
+  return Array.from(worldMap.values());
+}
+
+function StarDisplay({ count }: { count: number }) {
+  return (
+    <View style={styles.starsRow}>
+      {[0, 1, 2].map((i) => (
+        <Text
+          key={i}
+          style={[
+            styles.starIcon,
+            i < count ? styles.starFull : styles.starEmpty,
+          ]}
+        >
+          {i < count ? '\u2605' : '\u2606'}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+export default function LevelSelect({
+  progress,
+  onSelectLevel,
+  onFreePlay,
+}: LevelSelectProps) {
+  const worlds = getWorlds();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Select a Level</Text>
+
+      {worlds.map((w) => (
+        <View key={w.world} style={styles.worldSection}>
+          <Text
+            style={[
+              styles.worldHeader,
+              { color: WORLD_HEADER_COLORS[w.world] || '#fff' },
+            ]}
+          >
+            {w.worldName}
+          </Text>
+          <View style={styles.levelRow}>
+            {w.levels.map((level) => {
+              const unlocked = isLevelUnlocked(level.id, progress);
+              const prog = progress[level.id];
+              const completed = prog?.completed ?? false;
+              const stars = prog?.stars ?? 0;
+
+              return (
+                <TouchableOpacity
+                  key={level.id}
+                  style={[
+                    styles.levelButton,
+                    unlocked
+                      ? {
+                          backgroundColor:
+                            WORLD_COLORS[level.world] ||
+                            'rgba(255,255,255,0.2)',
+                        }
+                      : styles.levelLocked,
+                  ]}
+                  onPress={() => unlocked && onSelectLevel(level)}
+                  disabled={!unlocked}
+                  accessibilityLabel={
+                    unlocked
+                      ? `${level.label}${level.isBoss ? ' Boss' : ''}${completed ? `, ${stars} stars` : ''}`
+                      : `${level.label} locked`
+                  }
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: !unlocked }}
+                  testID={`level-${level.id}`}
+                >
+                  {unlocked ? (
+                    <>
+                      <Text style={styles.levelLabel}>
+                        {level.isBoss ? '\uD83D\uDC79' : level.id}
+                      </Text>
+                      <Text style={styles.levelDifficulty}>
+                        {level.difficulty}
+                      </Text>
+                      {completed && <StarDisplay count={stars} />}
+                    </>
+                  ) : (
+                    <>
+                      <Text style={styles.lockIcon}>{'\uD83D\uDD12'}</Text>
+                      <Text style={styles.levelLabelLocked}>{level.id}</Text>
+                    </>
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      ))}
+
+      <TouchableOpacity
+        style={styles.freePlayButton}
+        onPress={onFreePlay}
+        accessibilityLabel="Free Play mode"
+        accessibilityRole="button"
+        testID="free-play-button"
+      >
+        <Text style={styles.freePlayText}>Free Play</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center' as const,
+    paddingVertical: 16,
+    width: '100%',
+  },
+  title: {
+    fontSize: 32,
+    fontFamily: '"Fredoka One", "Quicksand", sans-serif',
+    color: '#fff',
+    textShadowColor: 'rgba(0, 0, 0, 0.75)',
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 4,
+    marginBottom: 16,
+  },
+  worldSection: {
+    width: '100%',
+    marginBottom: 16,
+  },
+  worldHeader: {
+    fontSize: 20,
+    fontFamily: '"Fredoka One", "Quicksand", sans-serif',
+    textShadowColor: 'rgba(0, 0, 0, 0.5)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 3,
+    marginBottom: 8,
+    paddingHorizontal: 4,
+  },
+  levelRow: {
+    flexDirection: 'row' as const,
+    gap: 10,
+    justifyContent: 'center' as const,
+    flexWrap: 'wrap' as const,
+  },
+  levelButton: {
+    width: 90,
+    height: 100,
+    borderRadius: 16,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    padding: 8,
+  },
+  levelLocked: {
+    backgroundColor: 'rgba(100, 100, 100, 0.5)',
+  },
+  levelLabel: {
+    fontSize: 24,
+    fontWeight: '700' as const,
+    fontFamily: '"Poppins", sans-serif',
+    color: '#fff',
+  },
+  levelDifficulty: {
+    fontSize: 11,
+    fontFamily: '"Quicksand", sans-serif',
+    color: 'rgba(255,255,255,0.8)',
+    textTransform: 'capitalize' as any,
+  },
+  levelLabelLocked: {
+    fontSize: 14,
+    fontFamily: '"Poppins", sans-serif',
+    color: 'rgba(255,255,255,0.4)',
+  },
+  lockIcon: {
+    fontSize: 22,
+  },
+  starsRow: {
+    flexDirection: 'row' as const,
+    gap: 2,
+    marginTop: 2,
+  },
+  starIcon: {
+    fontSize: 14,
+  },
+  starFull: {
+    color: '#FFD93D',
+  },
+  starEmpty: {
+    color: 'rgba(255,255,255,0.4)',
+  },
+  freePlayButton: {
+    marginTop: 16,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: 'rgba(255, 255, 255, 0.4)',
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    minHeight: 44,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  },
+  freePlayText: {
+    fontSize: 20,
+    fontFamily: '"Quicksand", sans-serif',
+    fontWeight: '700' as const,
+    color: '#fff',
+  },
+});

--- a/src/levels.test.ts
+++ b/src/levels.test.ts
@@ -1,0 +1,93 @@
+import { LEVELS, isLevelUnlocked, LevelProgress } from './levels';
+
+describe('LEVELS', () => {
+  it('has 12 levels', () => {
+    expect(LEVELS).toHaveLength(12);
+  });
+
+  it('has 4 worlds', () => {
+    const worlds = new Set(LEVELS.map((l) => l.world));
+    expect(worlds.size).toBe(4);
+    expect(worlds).toContain('addition');
+    expect(worlds).toContain('subtraction');
+    expect(worlds).toContain('multiplication');
+    expect(worlds).toContain('division');
+  });
+
+  it('has 4 boss levels', () => {
+    const bosses = LEVELS.filter((l) => l.isBoss);
+    expect(bosses).toHaveLength(4);
+  });
+
+  it('boss levels are every 3rd level per world', () => {
+    const bosses = LEVELS.filter((l) => l.isBoss);
+    expect(bosses.map((b) => b.id)).toEqual([3, 6, 9, 12]);
+  });
+});
+
+describe('isLevelUnlocked', () => {
+  it('level 1 is always unlocked', () => {
+    expect(isLevelUnlocked(1, {})).toBe(true);
+  });
+
+  it('level 2 is locked when level 1 not completed', () => {
+    expect(isLevelUnlocked(2, {})).toBe(false);
+  });
+
+  it('level 2 is unlocked when level 1 completed with 1+ star', () => {
+    const progress: Record<number, LevelProgress> = {
+      1: {
+        levelId: 1,
+        completed: true,
+        stars: 1,
+        bestScore: 10,
+        bestAccuracy: 70,
+      },
+    };
+    expect(isLevelUnlocked(2, progress)).toBe(true);
+  });
+
+  it('level 2 is locked when level 1 completed with 0 stars', () => {
+    const progress: Record<number, LevelProgress> = {
+      1: {
+        levelId: 1,
+        completed: true,
+        stars: 0,
+        bestScore: 0,
+        bestAccuracy: 0,
+      },
+    };
+    expect(isLevelUnlocked(2, progress)).toBe(false);
+  });
+
+  it('returns false for unknown level id', () => {
+    expect(isLevelUnlocked(999, {})).toBe(false);
+  });
+
+  it('level 4 (subtraction world) requires level 3 completed', () => {
+    const progress: Record<number, LevelProgress> = {
+      1: {
+        levelId: 1,
+        completed: true,
+        stars: 2,
+        bestScore: 20,
+        bestAccuracy: 80,
+      },
+      2: {
+        levelId: 2,
+        completed: true,
+        stars: 2,
+        bestScore: 20,
+        bestAccuracy: 80,
+      },
+      3: {
+        levelId: 3,
+        completed: true,
+        stars: 1,
+        bestScore: 10,
+        bestAccuracy: 70,
+      },
+    };
+    expect(isLevelUnlocked(4, progress)).toBe(true);
+  });
+});

--- a/src/levels.ts
+++ b/src/levels.ts
@@ -1,0 +1,164 @@
+export interface Level {
+  id: number;
+  world: string; // 'addition' | 'subtraction' | 'multiplication' | 'division'
+  worldName: string; // Display name
+  difficulty: string; // 'easy' | 'medium' | 'hard'
+  label: string; // e.g., "Addition 1", "Addition 2"
+  enemyCount: number; // problems to solve (5 for normal, 5 for boss with 5 HP)
+  isBoss: boolean; // boss level every 3rd level per world
+  requiredStars: number; // minimum stars from previous level to unlock (0 = always unlocked)
+}
+
+export const LEVELS: Level[] = [
+  // Addition World (levels 1-3)
+  {
+    id: 1,
+    world: 'addition',
+    worldName: 'Meadow',
+    difficulty: 'easy',
+    label: 'Addition 1',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 0,
+  },
+  {
+    id: 2,
+    world: 'addition',
+    worldName: 'Meadow',
+    difficulty: 'medium',
+    label: 'Addition 2',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 3,
+    world: 'addition',
+    worldName: 'Meadow',
+    difficulty: 'hard',
+    label: 'Addition 3',
+    enemyCount: 5,
+    isBoss: true,
+    requiredStars: 1,
+  },
+
+  // Subtraction World (levels 4-6)
+  {
+    id: 4,
+    world: 'subtraction',
+    worldName: 'Frozen Peaks',
+    difficulty: 'easy',
+    label: 'Subtraction 1',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 5,
+    world: 'subtraction',
+    worldName: 'Frozen Peaks',
+    difficulty: 'medium',
+    label: 'Subtraction 2',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 6,
+    world: 'subtraction',
+    worldName: 'Frozen Peaks',
+    difficulty: 'hard',
+    label: 'Subtraction 3',
+    enemyCount: 5,
+    isBoss: true,
+    requiredStars: 1,
+  },
+
+  // Multiplication World (levels 7-9)
+  {
+    id: 7,
+    world: 'multiplication',
+    worldName: 'Magic Forest',
+    difficulty: 'easy',
+    label: 'Multiplication 1',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 8,
+    world: 'multiplication',
+    worldName: 'Magic Forest',
+    difficulty: 'medium',
+    label: 'Multiplication 2',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 9,
+    world: 'multiplication',
+    worldName: 'Magic Forest',
+    difficulty: 'hard',
+    label: 'Multiplication 3',
+    enemyCount: 5,
+    isBoss: true,
+    requiredStars: 1,
+  },
+
+  // Division World (levels 10-12)
+  {
+    id: 10,
+    world: 'division',
+    worldName: 'Crystal Cave',
+    difficulty: 'easy',
+    label: 'Division 1',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 11,
+    world: 'division',
+    worldName: 'Crystal Cave',
+    difficulty: 'medium',
+    label: 'Division 2',
+    enemyCount: 5,
+    isBoss: false,
+    requiredStars: 1,
+  },
+  {
+    id: 12,
+    world: 'division',
+    worldName: 'Crystal Cave',
+    difficulty: 'hard',
+    label: 'Division 3',
+    enemyCount: 5,
+    isBoss: true,
+    requiredStars: 1,
+  },
+];
+
+export interface LevelProgress {
+  levelId: number;
+  completed: boolean;
+  stars: number; // 0-3
+  bestScore: number;
+  bestAccuracy: number;
+}
+
+export function isLevelUnlocked(
+  levelId: number,
+  progress: Record<number, LevelProgress>,
+): boolean {
+  const level = LEVELS.find((l) => l.id === levelId);
+  if (!level) return false;
+  if (level.id === 1) return true; // First level always unlocked
+
+  const prevLevel = LEVELS.find((l) => l.id === levelId - 1);
+  if (!prevLevel) return true;
+
+  const prevProgress = progress[prevLevel.id];
+  if (!prevProgress || !prevProgress.completed) return false;
+  return prevProgress.stars >= level.requiredStars;
+}


### PR DESCRIPTION
## Summary
- **12 structured levels** across 4 themed worlds (Meadow/Addition, Frozen Peaks/Subtraction, Magic Forest/Multiplication, Crystal Cave/Division)
- **Mastery-based unlocking**: complete previous level with 1+ star to advance; star ratings based on accuracy and speed
- **Level select screen** with world headers, lock/unlock indicators, star progress display, and a Free Play button for the original endless mode
- **Boss levels** every 3rd level per world (displayed with boss icon)
- **Progress persistence** via localStorage — stars, best score, and best accuracy saved per level
- New reducer actions: `SELECT_LEVEL`, `COMPLETE_LEVEL`, `BACK_TO_LEVELS`, `PLAY_FREE`
- Levels button in top bar for quick navigation back to level select

## Test plan
- [x] `yarn test --watchAll=false` — all 135 tests pass
- [x] New tests in `src/levels.test.ts`: level structure validation, `isLevelUnlocked` logic
- [x] New tests in `src/AppReducer.test.ts`: SELECT_LEVEL, COMPLETE_LEVEL, BACK_TO_LEVELS, PLAY_FREE actions
- [ ] Manual: verify level select renders on app load
- [ ] Manual: verify completing a level records stars and unlocks next level
- [ ] Manual: verify Free Play mode works identically to previous behavior
- [ ] Manual: verify Back to Levels button on victory screen returns to level select

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)