### PR TITLE
feat: add boss battles with HP bar and 3x points

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,12 @@
         60% { transform: scale(1.1) translateY(5px); opacity: 1; }
         100% { transform: scale(1) translateY(0); opacity: 1; }
       }
+      @keyframes bossEntrance {
+        0% { transform: scale(0) rotate(-10deg); opacity: 0; }
+        60% { transform: scale(1.2) rotate(5deg); opacity: 1; }
+        80% { transform: scale(0.95) rotate(-2deg); }
+        100% { transform: scale(1) rotate(0deg); opacity: 1; }
+      }
       @media (prefers-reduced-motion: reduce) {
         * {
           animation-duration: 0.01ms !important;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,6 +180,9 @@ function App() {
       gameScreen,
       locale,
       isDailyChallenge,
+      isBossLevel,
+      bossHP,
+      bossMaxHP,
     },
     dispatch,
   ] = useReducer(reducer, initialState);
@@ -441,12 +444,12 @@ function App() {
   useEffect(() => {
     if (won) return;
     dispatch({ type: TYPES.START_TIMER });
-    setTimeLeft(30);
+    setTimeLeft(isBossLevel ? 20 : 30);
     const interval = setInterval(() => {
       setTimeLeft((prev) => (prev > 0 ? prev - 1 : 0));
     }, 1000);
     return () => clearInterval(interval);
-  }, [val1, val2, won]);
+  }, [val1, val2, won, isBossLevel]);
   useEffect(() => {
     if (lastPointsEarned == null) return;
     setShowPoints(true);
@@ -759,44 +762,94 @@ function App() {
                   </View>
                 </View>
                 <View style={styles.enemiesContainer}>
-                  {[...Array(numOfEnemies)].map((_, i) => (
-                    <View
-                      testID="enemies"
-                      key={i}
-                      style={
-                        defeatingEnemy && i === numOfEnemies - 1
-                          ? ({
-                              animationName: 'enemyDefeat',
-                              animationDuration: '0.5s',
-                              animationFillMode: 'forwards',
-                            } as any)
-                          : undefined
-                      }
-                    >
-                      <Image
-                        source={enemyImages[mode] || enemyImages.addition}
-                        style={[
-                          styles.characterImage,
-                          defeatingEnemy && i === numOfEnemies - 1
-                            ? undefined
-                            : newEnemyIndex === i
-                              ? ({
-                                  animationName: 'enemyEntrance',
-                                  animationDuration: '0.5s',
-                                  animationFillMode: 'forwards',
-                                } as any)
+                  {isBossLevel ? (
+                    <View testID="enemies" style={{ alignItems: 'center' }}>
+                      <View
+                        style={
+                          defeatingEnemy && bossHP <= 0
+                            ? ({
+                                animationName: 'enemyDefeat',
+                                animationDuration: '0.5s',
+                                animationFillMode: 'forwards',
+                              } as any)
+                            : undefined
+                        }
+                      >
+                        <Image
+                          source={enemyImages[mode] || enemyImages.addition}
+                          style={[
+                            styles.bossImage,
+                            {
+                              boxShadow:
+                                '0 0 30px rgba(255, 80, 0, 0.7), 0 0 60px rgba(255, 0, 0, 0.4)',
+                            } as any,
+                            defeatingEnemy && bossHP <= 0
+                              ? undefined
                               : ({
-                                  animationName: 'enemySway',
-                                  animationDuration: '1.5s',
-                                  animationIterationCount: 'infinite',
-                                  animationTimingFunction: 'ease-in-out',
-                                  animationDelay: `${i * 0.3}s`,
+                                  animationName: 'bossEntrance',
+                                  animationDuration: '0.8s',
+                                  animationFillMode: 'forwards',
+                                  animationIterationCount:
+                                    numOfEnemies > 0 ? 1 : undefined,
                                 } as any),
-                        ]}
-                        accessibilityLabel={`Enemy ${i + 1}`}
-                      />
+                          ]}
+                          accessibilityLabel="Boss Enemy"
+                        />
+                      </View>
+                      <View style={styles.bossHPBar}>
+                        <View
+                          style={[
+                            styles.bossHPFill,
+                            {
+                              width: `${(bossHP / bossMaxHP) * 100}%`,
+                            },
+                          ]}
+                        />
+                        <Text
+                          style={styles.bossHPText}
+                        >{`${bossHP} / ${bossMaxHP}`}</Text>
+                      </View>
                     </View>
-                  ))}
+                  ) : (
+                    [...Array(numOfEnemies)].map((_, i) => (
+                      <View
+                        testID="enemies"
+                        key={i}
+                        style={
+                          defeatingEnemy && i === numOfEnemies - 1
+                            ? ({
+                                animationName: 'enemyDefeat',
+                                animationDuration: '0.5s',
+                                animationFillMode: 'forwards',
+                              } as any)
+                            : undefined
+                        }
+                      >
+                        <Image
+                          source={enemyImages[mode] || enemyImages.addition}
+                          style={[
+                            styles.characterImage,
+                            defeatingEnemy && i === numOfEnemies - 1
+                              ? undefined
+                              : newEnemyIndex === i
+                                ? ({
+                                    animationName: 'enemyEntrance',
+                                    animationDuration: '0.5s',
+                                    animationFillMode: 'forwards',
+                                  } as any)
+                                : ({
+                                    animationName: 'enemySway',
+                                    animationDuration: '1.5s',
+                                    animationIterationCount: 'infinite',
+                                    animationTimingFunction: 'ease-in-out',
+                                    animationDelay: `${i * 0.3}s`,
+                                  } as any),
+                          ]}
+                          accessibilityLabel={`Enemy ${i + 1}`}
+                        />
+                      </View>
+                    ))
+                  )}
                 </View>
               </View>
               {/* === ATTEMPT HEARTS === */}
@@ -1433,6 +1486,37 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontFamily: '"Quicksand", sans-serif',
     fontWeight: '600' as const,
+  },
+  bossHPBar: {
+    width: '80%',
+    maxWidth: 200,
+    height: 20,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    borderRadius: 10,
+    overflow: 'hidden' as any,
+    alignSelf: 'center' as const,
+    marginTop: 4,
+    position: 'relative' as const,
+  },
+  bossHPFill: {
+    height: '100%',
+    backgroundColor: '#f44336',
+    borderRadius: 10,
+  },
+  bossHPText: {
+    position: 'absolute' as const,
+    width: '100%',
+    textAlign: 'center' as const,
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold' as const,
+    fontFamily: '"Poppins", sans-serif',
+    lineHeight: 20,
+  },
+  bossImage: {
+    width: 180,
+    height: 180,
+    resizeMode: 'contain' as any,
   },
   enemyCount: { paddingVertical: 4 },
   enemyCountText: {

--- a/src/AppReducer.test.ts
+++ b/src/AppReducer.test.ts
@@ -1353,3 +1353,128 @@ describe('answer mode', () => {
     expect(result.choices).toEqual([]);
   });
 });
+
+describe('Boss battles', () => {
+  const bossLevel = LEVELS.find((l) => l.isBoss)!;
+
+  it('SELECT_LEVEL with boss level sets isBossLevel, bossHP, bossMaxHP', () => {
+    const state = makeState();
+    const result = reducer(state, {
+      type: TYPES.SELECT_LEVEL,
+      payload: bossLevel,
+    });
+
+    expect(result.isBossLevel).toBe(true);
+    expect(result.bossHP).toBe(5);
+    expect(result.bossMaxHP).toBe(5);
+    expect(result.numOfEnemies).toBe(1);
+  });
+
+  it('SELECT_LEVEL with non-boss level does not set boss fields', () => {
+    const normalLevel = LEVELS.find((l) => !l.isBoss)!;
+    const state = makeState();
+    const result = reducer(state, {
+      type: TYPES.SELECT_LEVEL,
+      payload: normalLevel,
+    });
+
+    expect(result.isBossLevel).toBe(false);
+    expect(result.bossHP).toBe(0);
+    expect(result.bossMaxHP).toBe(0);
+    expect(result.numOfEnemies).toBe(normalLevel.enemyCount);
+  });
+
+  it('CHECK_ANSWER correct on boss decrements bossHP but keeps enemy', () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now + 3000);
+    const state = makeState({
+      val1: 2,
+      val2: 3,
+      operator: '+',
+      mode: 'addition',
+      answer: '5',
+      numOfEnemies: 1,
+      previousNumOfEnemies: 1,
+      modeType: 'wholeNumber',
+      questionStartTime: now,
+      isBossLevel: true,
+      bossHP: 5,
+      bossMaxHP: 5,
+    });
+    const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+
+    expect(result.bossHP).toBe(4);
+    expect(result.numOfEnemies).toBe(1);
+    expect(result.won).toBe(false);
+    expect(result.isBossLevel).toBe(true);
+    jest.restoreAllMocks();
+  });
+
+  it('CHECK_ANSWER correct when bossHP reaches 0 triggers won', () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now + 3000);
+    const state = makeState({
+      val1: 2,
+      val2: 3,
+      operator: '+',
+      mode: 'addition',
+      answer: '5',
+      numOfEnemies: 1,
+      previousNumOfEnemies: 1,
+      modeType: 'wholeNumber',
+      questionStartTime: now,
+      isBossLevel: true,
+      bossHP: 1,
+      bossMaxHP: 5,
+    });
+    const result = reducer(state, { type: TYPES.CHECK_ANSWER });
+
+    expect(result.bossHP).toBe(0);
+    expect(result.numOfEnemies).toBe(0);
+    expect(result.won).toBe(true);
+    jest.restoreAllMocks();
+  });
+
+  it('boss points are 3x multiplied', () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now + 3000);
+
+    // Normal level: should get 10 points (under 5s, first attempt)
+    const normalState = makeState({
+      val1: 2,
+      val2: 3,
+      operator: '+',
+      mode: 'addition',
+      answer: '5',
+      numOfEnemies: 3,
+      previousNumOfEnemies: 3,
+      modeType: 'wholeNumber',
+      questionStartTime: now,
+      isBossLevel: false,
+      bossHP: 0,
+      bossMaxHP: 0,
+    });
+    const normalResult = reducer(normalState, { type: TYPES.CHECK_ANSWER });
+
+    // Boss level: should get 30 points (10 * 3x)
+    const bossState = makeState({
+      val1: 2,
+      val2: 3,
+      operator: '+',
+      mode: 'addition',
+      answer: '5',
+      numOfEnemies: 1,
+      previousNumOfEnemies: 1,
+      modeType: 'wholeNumber',
+      questionStartTime: now,
+      isBossLevel: true,
+      bossHP: 5,
+      bossMaxHP: 5,
+    });
+    const bossResult = reducer(bossState, { type: TYPES.CHECK_ANSWER });
+
+    expect(normalResult.lastPointsEarned).toBe(10);
+    expect(bossResult.lastPointsEarned).toBe(30);
+    jest.restoreAllMocks();
+  });
+});

--- a/src/AppReducer.ts
+++ b/src/AppReducer.ts
@@ -104,6 +104,9 @@ export type AppState = {
   dailyProblems: DailyProblem[];
   dailyProblemIndex: number;
   locale: Locale;
+  isBossLevel: boolean;
+  bossHP: number;
+  bossMaxHP: number;
 };
 
 export function calculateStars(
@@ -161,6 +164,9 @@ export const initialState: AppState = {
   dailyProblems: [],
   dailyProblemIndex: 0,
   locale: 'en' as Locale,
+  isBossLevel: false,
+  bossHP: 0,
+  bossMaxHP: 0,
 };
 
 /**
@@ -361,11 +367,18 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         locale: state.locale,
         gameScreen: 'playing',
         numOfEnemies: state.currentLevel
-          ? state.currentLevel.enemyCount
+          ? state.currentLevel.isBoss
+            ? 1
+            : state.currentLevel.enemyCount
           : initialState.numOfEnemies,
         previousNumOfEnemies: state.currentLevel
-          ? state.currentLevel.enemyCount
+          ? state.currentLevel.isBoss
+            ? 1
+            : state.currentLevel.enemyCount
           : initialState.numOfEnemies,
+        isBossLevel: state.currentLevel?.isBoss === true,
+        bossHP: state.currentLevel?.isBoss ? 5 : 0,
+        bossMaxHP: state.currentLevel?.isBoss ? 5 : 0,
       };
     }
 
@@ -447,7 +460,10 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         const basePoints = calculatePoints(elapsed);
         const attemptMultiplier =
           state.attempts === 0 ? 1 : state.attempts === 1 ? 0.5 : 0.25;
-        const pointsEarned = Math.round(basePoints * attemptMultiplier);
+        const bossMultiplier = state.isBossLevel ? 3 : 1;
+        const pointsEarned = Math.round(
+          basePoints * attemptMultiplier * bossMultiplier,
+        );
 
         const newStreak = state.streak + 1;
         const newMaxStreak = Math.max(state.maxStreak, newStreak);
@@ -459,6 +475,55 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
 
         const newCorrectAttempts = state.correctAttempts + 1;
         const newTotalAnswerTime = state.totalAnswerTime + elapsed;
+
+        // Boss levels: decrement HP instead of removing enemy immediately
+        if (state.isBossLevel) {
+          const newBossHP = state.bossHP - 1;
+          const bossDefeated = newBossHP <= 0;
+
+          const stateForProblem = {
+            ...state,
+            difficulty: newDifficulty,
+            numOfEnemies: bossDefeated ? 0 : 1,
+            previousNumOfEnemies: 1,
+            won: bossDefeated,
+            bossHP: newBossHP,
+          };
+          const stateWithProblem = bossDefeated
+            ? stateForProblem
+            : reducer(stateForProblem, { type: TYPES.NEW_PROBLEM });
+
+          const starsEarned = bossDefeated
+            ? calculateStars(
+                newCorrectAttempts,
+                newTotalAttempts,
+                newTotalAnswerTime,
+              )
+            : state.starsEarned;
+
+          return {
+            ...stateWithProblem,
+            score: newScore,
+            bestScore: newBestScore,
+            lastPointsEarned: pointsEarned,
+            questionStartTime: Date.now(),
+            attempts: 0,
+            hintLevel: 0,
+            recentResults: newRecentResults,
+            difficulty: newDifficulty,
+            adaptiveMessage,
+            streak: newStreak,
+            maxStreak: newMaxStreak,
+            streakBonus,
+            totalAttempts: newTotalAttempts,
+            correctAttempts: newCorrectAttempts,
+            totalAnswerTime: newTotalAnswerTime,
+            starsEarned,
+            isBossLevel: state.isBossLevel,
+            bossHP: newBossHP,
+            bossMaxHP: state.bossMaxHP,
+          };
+        }
 
         const stateWithEnemies = reducer(
           { ...state, difficulty: newDifficulty },
@@ -685,6 +750,7 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         state.answerMode === 'choose'
           ? generateChoices(computeAnswer(val[0], op, val[1]))
           : [];
+      const isBoss = level.isBoss === true;
       return {
         ...initialState,
         mode,
@@ -693,8 +759,8 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         operator: op,
         val1: val[0],
         val2: val[1],
-        numOfEnemies: level.enemyCount,
-        previousNumOfEnemies: level.enemyCount,
+        numOfEnemies: isBoss ? 1 : level.enemyCount,
+        previousNumOfEnemies: isBoss ? 1 : level.enemyCount,
         currentLevel: level,
         levelProgress: state.levelProgress,
         gameScreen: 'playing',
@@ -706,6 +772,9 @@ export const reducer: Reducer<AppState, ActionType> = (state, action) => {
         choices,
         hasSeenTutorial: state.hasSeenTutorial,
         locale: state.locale,
+        isBossLevel: isBoss,
+        bossHP: isBoss ? 5 : 0,
+        bossMaxHP: isBoss ? 5 : 0,
       };
     }
 


### PR DESCRIPTION
## Summary
- Boss levels (every 3rd level per world, `isBoss: true`) now feature a single large boss enemy with 5 HP requiring 5 correct answers to defeat
- Boss timer is shortened to 20s (vs 30s normal), points are multiplied by 3x
- Boss enemy renders at 1.5x size (180x180) with red/orange glow and dramatic entrance animation
- HP bar displayed below boss showing remaining health
- 5 new unit tests covering boss SELECT_LEVEL, HP decrement, victory trigger, and 3x scoring

## Test plan
- [x] `yarn test --watchAll=false --testPathPattern=AppReducer` passes all 112 tests
- [ ] Manually verify boss level selection shows single large enemy with HP bar
- [ ] Verify correct answers decrement HP bar, boss defeated at 0 HP
- [ ] Verify timer starts at 20s on boss levels
- [ ] Verify 3x point multiplier on boss levels

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)